### PR TITLE
misleading indentations in tls.c und tcp.c

### DIFF
--- a/tcp.c
+++ b/tcp.c
@@ -336,8 +336,8 @@ void *tcpservernew(void *arg) {
     if (conf) {
 	client = addclient(conf, 1);
 	if (client) {
-        if(conf->keepalive)
-            enable_keepalive(s);
+            if(conf->keepalive)
+                enable_keepalive(s);
 	    client->sock = s;
 	    client->addr = addr_copy((struct sockaddr *)&from);
 	    tcpserverrd(client);

--- a/tcp.c
+++ b/tcp.c
@@ -119,8 +119,8 @@ int tcpconnect(struct server *server, struct timeval *when, int timeout, char *t
 	if (server->sock >= 0)
 	    close(server->sock);
 	if ((server->sock = connecttcphostlist(server->conf->hostports, srcres)) >= 0) {
-        if (server->conf->keepalive)
-            enable_keepalive(server->sock);
+            if (server->conf->keepalive)
+                enable_keepalive(server->sock);
 	    break;
 	}
     }

--- a/tls.c
+++ b/tls.c
@@ -130,8 +130,8 @@ int tlsconnect(struct server *server, struct timeval *when, int timeout, char *t
 	if ((server->sock = connecttcphostlist(server->conf->hostports, srcres)) < 0)
 	    continue;
 
-    if (server->conf->keepalive)
-        enable_keepalive(server->sock);
+        if (server->conf->keepalive)
+            enable_keepalive(server->sock);
 
 	SSL_free(server->ssl);
 	server->ssl = NULL;


### PR DESCRIPTION
Hi,

imho there are misleading indentations in tls.c und tcp.c in the master branch and gcc 6.31 throws a warning: [-Wmisleading-indentation].

Cheers,
Helge