### PR TITLE
Add missing #include to tests/t_fticks.c

### DIFF
--- a/tests/t_fticks.c
+++ b/tests/t_fticks.c
@@ -2,6 +2,7 @@
 /* See LICENSE for licensing information. */
 
 #include <stdio.h>
+#include <string.h>
 #include <errno.h>
 #include "../radsecproxy.h"
 #include "../fticks_hashmac.h"


### PR DESCRIPTION
tests/t_fticks.c uses strcmp, but did not include <string.h>, which at
least in some environments made the build fail.