### PR TITLE
Switch to OpenSSL's THREADID API

### DIFF
--- a/tlscommon.c
+++ b/tlscommon.c
@@ -44,8 +44,8 @@ static uint8_t cookie_secret_initialized = 0;
 #if OPENSSL_VERSION_NUMBER < 0x10100000
 static pthread_mutex_t *ssl_locks = NULL;
 
-unsigned long ssl_thread_id() {
-    return (unsigned long)pthread_self();
+void ssl_thread_id(CRYPTO_THREADID *id) {
+    CRYPTO_THREADID_set_numeric(id, (unsigned long)pthread_self());
 }
 
 void ssl_locking_callback(int mode, int type, const char *file, int line) {
@@ -69,7 +69,7 @@ void sslinit() {
     for (i = 0; i < CRYPTO_num_locks(); i++) {
         pthread_mutex_init(&ssl_locks[i], NULL);
     }
-    CRYPTO_set_id_callback(ssl_thread_id);
+    CRYPTO_THREADID_set_callback(ssl_thread_id);
     CRYPTO_set_locking_callback(ssl_locking_callback);
     SSL_load_error_strings();
 #else


### PR DESCRIPTION
The old callback was deprecated in version 1.0.0 of OpenSSL

Fixes compilation without deprecated APIs enabled on 1.0.2.