### PR TITLE
Fix compilation on FreeBSD

### DIFF
--- a/radsecproxy.c
+++ b/radsecproxy.c
@@ -1997,8 +1997,13 @@ void createlistener(uint8_t type, char *arg) {
             if (setsockopt(s, IPPROTO_IPV6, IPV6_RECVPKTINFO, &on, sizeof(on)) == -1)
                 debugerrno(errno, DBG_WARN, "craetelistener: IPV6_RECVPKTINFO");
         } else if (res->ai_family == AF_INET) {
+#if defined(IP_PKTINFO)
             if (setsockopt(s, IPPROTO_IP, IP_PKTINFO, &on, sizeof(on)) == -1)
                 debugerrno(errno, DBG_WARN, "createlistener: IP_PKTINFO");
+#elif defined(IP_RECVDSTADDR)
+            if (setsockopt(s, IPPROTO_IP, IP_RECVDSTADDR, &on, sizeof(on)) == -1)
+                debugerrno(errno, DBG_WARN, "createlistener: IP_RECVDSTADDR");
+#endif
         }
     }
 	if (bind(s, res->ai_addr, res->ai_addrlen)) {

--- a/util.c
+++ b/util.c
@@ -129,15 +129,15 @@ void enable_keepalive(int socket) {
     debug(DBG_NOTICE, "TCP Keepalive feature might be limited on this platform");
 #else
     optval = 3;
-    if(setsockopt(socket, SOL_TCP, TCP_KEEPCNT, &optval, optlen) < 0) {
+    if(setsockopt(socket, IPPROTO_TCP, TCP_KEEPCNT, &optval, optlen) < 0) {
         debug(DBG_ERR, "enable_keepalive: setsockopt TCP_KEEPCNT failed");
     }
     optval = 10;
-    if(setsockopt(socket, SOL_TCP, TCP_KEEPIDLE, &optval, optlen) < 0) {
+    if(setsockopt(socket, IPPROTO_TCP, TCP_KEEPIDLE, &optval, optlen) < 0) {
         debug(DBG_ERR, "enable_keepalive: setsockopt TCP_KEEPIDLE %d failed", optval);
     }
     optval = 10;
-    if(setsockopt(socket, SOL_TCP, TCP_KEEPINTVL, &optval, optlen) < 0) {
+    if(setsockopt(socket, IPPROTO_TCP, TCP_KEEPINTVL, &optval, optlen) < 0) {
         debug(DBG_ERR, "enable_keepalive: setsockopt TCP_KEEPINTVL failed");
     }
 #endif


### PR DESCRIPTION
This fixes compilation on FreeBSD systems, addressing the issue mentioned in #25 plus another one spot where non-portable code was used.

This is untested, but seems to build on both Linux and FreeBSD systems.