### PR TITLE
 Compilation fails under Alpine Linux

### DIFF
--- a/radsecproxy.c
+++ b/radsecproxy.c
@@ -1091,8 +1091,8 @@ struct clsrvconf *choosesrvconf(struct list *srvconfs) {
         server = (struct clsrvconf *)entry->data;
         if (!server->servers)
             return server;
-            if (server->servers->state == RSP_SERVER_STATE_FAILING)
-                continue;
+        if (server->servers->state == RSP_SERVER_STATE_FAILING)
+            continue;
         if (!first)
             first = server;
         if (server->servers->state == RSP_SERVER_STATE_STARTUP || server->servers->state == RSP_SERVER_STATE_RECONNECTING)

--- a/util.c
+++ b/util.c
@@ -15,7 +15,6 @@
 #include <poll.h>
 #include <stdarg.h>
 #include <assert.h>
-#include <sys/time.h>
 #include "debug.h"
 #include "util.h"
 

--- a/util.h
+++ b/util.h
@@ -3,6 +3,7 @@
 /* See LICENSE for licensing information. */
 
 #include <sys/socket.h>
+#include <sys/time.h>
 #include <netdb.h>
 
 #define SOCKADDR_SIZE(addr) ((addr).ss_family == AF_INET ?	\


### PR DESCRIPTION
This should fix issue #37 by moving the include of "sys/time.h" from util.c to util.h and correcting the indentation of the if clause at line 1094 (radsecproxy.c)