### PR TITLE
Add arpa/inet.h include because of htonl ntohl

### DIFF
--- a/rewrite.c
+++ b/rewrite.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <regex.h>
+#include <arpa/inet.h>
 #include "debug.h"
 #include "gconfig.h"
 #include "hash.h"


### PR DESCRIPTION
When attempting to compile on FreeBSD, the compiler complains that `htonl` and `ntohl` are implicitly declared. I'm assuming that these are inherited from arpa/inet.h, so just adding the include should fix the problem.