### PR TITLE
Do not cast to BIO_ADDR when using LibreSSL

### DIFF
--- a/dtls.c
+++ b/dtls.c
@@ -491,7 +491,7 @@ void *dtlslistener(void *arg) {
             BIO_set_fd(SSL_get_rbio(conf->tlsconf->dtlssslprep), s, BIO_NOCLOSE);
         }
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000
+#if OPENSSL_VERSION_NUMBER < 0x10100000 || LIBRESSL_VERSION_NUMBER
         if(DTLSv1_listen(conf->tlsconf->dtlssslprep, &from) > 0) {
 #else
         if(DTLSv1_listen(conf->tlsconf->dtlssslprep, (BIO_ADDR *)&from) > 0) {

--- a/dtls.c
+++ b/dtls.c
@@ -491,7 +491,7 @@ void *dtlslistener(void *arg) {
             BIO_set_fd(SSL_get_rbio(conf->tlsconf->dtlssslprep), s, BIO_NOCLOSE);
         }
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000 || LIBRESSL_VERSION_NUMBER
+#if (OPENSSL_VERSION_NUMBER < 0x10100000) || defined(LIBRESSL_VERSION_NUMBER)
         if(DTLSv1_listen(conf->tlsconf->dtlssslprep, &from) > 0) {
 #else
         if(DTLSv1_listen(conf->tlsconf->dtlssslprep, (BIO_ADDR *)&from) > 0) {


### PR DESCRIPTION
When compiling on FreeBSD using libressl, compilation failed because `BIO_ADDR` is an unknown symbol in LibreSSL. I didn't get any new warnings from this change AFAIC.