### PR TITLE
Add spec file for RHEL+ rpm building

### DIFF
--- a/packaging/rpm/README.md
+++ b/packaging/rpm/README.md
@@ -1,26 +1,8 @@
 # CentOS/Fedora package for radsecproxy
 
-  * Project page: https://radsecproxy.github.io/
-  * Package page: https://copr.fedorainfracloud.org/coprs/jornane/radsecproxy/
+Project page: https://radsecproxy.github.io/
 
-
-# Install
-
-## CentOS / Red Hat
-
-	yum install yum-plugin-copr
-	yum copr enable jornane/radsecproxy
-	yum install radsecproxy
-
-
-## Fedora
-
-	dnf install dnf-plugins-core
-	dnf copr enable jornane/radsecproxy
-	dnf install radsecproxy
-
-
-# Build locally
+# Build
 
 	sh build.sh
 

--- a/packaging/rpm/README.md
+++ b/packaging/rpm/README.md
@@ -1,0 +1,27 @@
+# CentOS/Fedora package for radsecproxy
+
+  * Project page: https://radsecproxy.github.io/
+  * Package page: https://copr.fedorainfracloud.org/coprs/jornane/radsecproxy/
+
+
+# Install
+
+## CentOS / Red Hat
+
+	yum install yum-plugin-copr
+	yum copr enable jornane/radsecproxy
+	yum install radsecproxy
+
+
+## Fedora
+
+	dnf install dnf-plugins-core
+	dnf copr enable jornane/radsecproxy
+	dnf install radsecproxy
+
+
+# Build locally
+
+	sh build.sh
+
+If everything goes well, the resulting RPM file will be in `~/rpmbuild/RPMS`

--- a/packaging/rpm/build.sh
+++ b/packaging/rpm/build.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -ex
+yum install rpmdevtools gcc make nettle-devel openssl-devel
+rpmdev-setuptree
+spectool -g -R radsecproxy.spec
+cp patch-* *.service ~/rpmbuild/SOURCES/
+rpmbuild -bb radsecproxy.spec

--- a/packaging/rpm/patch-radsecproxy.conf-example
+++ b/packaging/rpm/patch-radsecproxy.conf-example
@@ -1,12 +1,6 @@
---- radsecproxy.conf-example.orig	2019-09-17 15:39:48.776488895 +0200
-+++ radsecproxy.conf-example	2019-09-17 16:03:54.208480060 +0200
-@@ -1,4 +1,4 @@
--# Master config file, must be in /usr/local/etc/radsecproxy or specified with -c option
-+# Master config file, /etc/radsecproxy.conf or specified with -c option
- #	All possible config options are listed below
- 
- # First you may define any global options, these are:
-@@ -91,12 +91,12 @@
+--- radsecproxy.conf-example.orig	2019-10-03 18:29:12.434977076 +0200
++++ radsecproxy.conf-example	2019-10-03 18:29:57.124976803 +0200
+@@ -90,12 +90,12 @@
  tls default {
      # You must specify at least one of CACertificateFile or CACertificatePath
      # for TLS to work. We always verify peer certificate (client and server)

--- a/packaging/rpm/patch-radsecproxy.conf-example
+++ b/packaging/rpm/patch-radsecproxy.conf-example
@@ -1,0 +1,25 @@
+--- radsecproxy.conf-example.orig	2019-09-17 15:39:48.776488895 +0200
++++ radsecproxy.conf-example	2019-09-17 16:03:54.208480060 +0200
+@@ -1,4 +1,4 @@
+-# Master config file, must be in /usr/local/etc/radsecproxy or specified with -c option
++# Master config file, /etc/radsecproxy.conf or specified with -c option
+ #	All possible config options are listed below
+ 
+ # First you may define any global options, these are:
+@@ -91,12 +91,12 @@
+ tls default {
+     # You must specify at least one of CACertificateFile or CACertificatePath
+     # for TLS to work. We always verify peer certificate (client and server)
+-    # CACertificateFile    /etc/cacerts/CA.pem
+-    CACertificatePath	/etc/cacerts
++    # CACertificateFile    /etc/pki/radsecproxy/cacerts/CA.pem
++    CACertificatePath	/etc/pki/radsecproxy/cacerts
+ 
+     # You must specify the below for TLS, we always present our certificate
+-    CertificateFile	/etc/hostcertkey/host.example.com.pem
+-    CertificateKeyFile	/etc/hostcertkey/host.example.com.key.pem
++    CertificateFile	/etc/pki/radsecproxy/host.example.com.pem
++    CertificateKeyFile	/etc/pki/radsecproxy/host.example.com.key.pem
+     # Optionally specify password if key is encrypted (not very secure)
+     CertificateKeyPassword	"follow the white rabbit"
+     # Optionally enable CRL checking

--- a/packaging/rpm/radsecproxy.service
+++ b/packaging/rpm/radsecproxy.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=radsecproxy
+ConditionPathExists=/etc/radsecproxy.conf
+After=network.target
+Documentation=man:radsecproxy(1)
+
+[Service]
+Type=forking
+ExecStart=/usr/sbin/radsecproxy
+User=radsecproxy
+ProtectSystem=full
+PrivateDevices=true
+PrivateTmp=true
+ProtectHome=true
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/rpm/radsecproxy.spec
+++ b/packaging/rpm/radsecproxy.spec
@@ -1,6 +1,6 @@
 Name:			radsecproxy
-Version:		1.8.0
-Release:		4%{?dist}
+Version:		1.8.1
+Release:		1%{?dist}
 Summary:		A generic RADIUS proxy
 
 License:		BSD

--- a/packaging/rpm/radsecproxy.spec
+++ b/packaging/rpm/radsecproxy.spec
@@ -1,0 +1,75 @@
+Name:			radsecproxy
+Version:		1.8.0
+Release:		4%{?dist}
+Summary:		A generic RADIUS proxy
+
+License:		BSD
+URL:			https://radsecproxy.github.io/
+Source0:		https://github.com/radsecproxy/%{name}/releases/download/%{version}/%{name}-%{version}.tar.gz
+Source1:		radsecproxy.service
+Patch0:			patch-radsecproxy.conf-example
+BuildRequires:		gcc
+BuildRequires:		make
+BuildRequires:		nettle-devel
+BuildRequires:		openssl-devel
+%if 0%{?fedora} >= 30
+BuildRequires:		systemd-rpm-macros
+%else
+BuildRequires:		systemd
+%endif
+Requires(pre):		shadow-utils
+Requires(preun):	systemd-units
+Requires(postun):	systemd-units
+
+%description
+radsecproxy is a generic RADIUS proxy that in addition to usual RADIUS UDP
+transport, also supports TLS (RadSec), as well as RADIUS over TCP and DTLS.
+The aim is for the proxy to have sufficient features to be flexible, while
+at the same time to be small, efficient and easy to configure.
+
+%pre
+/usr/bin/getent group  radsecproxy >/dev/null || /usr/sbin/groupadd -r radsecproxy
+/usr/bin/getent passwd radsecproxy >/dev/null || \
+	/usr/sbin/useradd -r -g radsecproxy -d /var/empty -s /sbin/nologin -c "radsecproxy user" radsecproxy
+exit 0
+
+%preun
+%systemd_preun radsecproxy.service
+
+%postun
+%systemd_postun_with_restart radsecproxy.service
+if [ $1 -eq 0 ]; then # uninstall
+	/usr/bin/getent passwd radsecproxy >/dev/null && /usr/sbin/userdel  radiusd >/dev/null 2>&1
+	/usr/bin/getent group  radsecproxy >/dev/null && /usr/sbin/groupdel radiusd >/dev/null 2>&1
+fi
+exit 0
+
+%prep
+%autosetup
+
+%build
+%configure
+%make_build
+
+%install
+%make_install
+mkdir -p %{buildroot}%{_sysconfdir} %{buildroot}%{_unitdir}
+cp radsecproxy.conf-example %{buildroot}%{_sysconfdir}/radsecproxy.conf
+cp %{SOURCE1} %{buildroot}%{_unitdir}/radsecproxy.service
+
+%files
+%{_bindir}/radsecproxy-conf
+%{_bindir}/radsecproxy-hash
+%{_sbindir}/radsecproxy
+%{_mandir}/man1/radsecproxy-hash.1.gz
+%{_mandir}/man1/radsecproxy.1.gz
+%{_mandir}/man5/radsecproxy.conf.5.gz
+%{_unitdir}/radsecproxy.service
+%attr(0640,root,radsecproxy) %config(noreplace) %{_sysconfdir}/radsecproxy.conf
+
+%license LICENSE
+%doc ChangeLog AUTHORS NEWS README THANKS
+
+%changelog
+* Tue Sep 17 2019 Jørn Åne de Jong <jorn.dejong@uninett.no>
+- Initial build.


### PR DESCRIPTION
Heavily inspired from #40, this .spec file will build and install on CentOS 7, Fedora 29-31 and RHEL 8 beta.