### PR TITLE
Declare pthread_attr as extern in header (fixes #63)

### DIFF
--- a/radsecproxy.c
+++ b/radsecproxy.c
@@ -84,6 +84,7 @@ extern int optind;
 extern char *optarg;
 #endif
 static const struct protodefs *protodefs[RAD_PROTOCOUNT];
+pthread_attr_t pthread_attr;
 
 /* minimum required declarations to avoid reordering code */
 struct realm *adddynamicrealmserver(struct realm *realm, char *id);

--- a/radsecproxy.h
+++ b/radsecproxy.h
@@ -263,7 +263,7 @@ int radsrv(struct request *rq);
 void replyh(struct server *server, unsigned char *buf);
 struct addrinfo *resolve_hostport_addrinfo(uint8_t type, char *hostport);
 uint8_t *radattr2ascii(struct tlv *attr); /* TODO: mv this to radmsg? */
-pthread_attr_t pthread_attr;
+extern pthread_attr_t pthread_attr;
 
 /* Local Variables: */
 /* c-file-style: "stroustrup" */


### PR DESCRIPTION
GCC 10 compatibility as per https://gcc.gnu.org/gcc-10/porting_to.html