### PR TITLE
Log incoming accounting packets at NOTICE

### DIFF
--- a/raddict.h
+++ b/raddict.h
@@ -1,7 +1,7 @@
 #ifndef RAD_DICT
 #define RAD_DICT
 
-char* RAD_Attr_Acct_Terminate_Cause_Dict[] = {
+const char* RAD_Attr_Acct_Terminate_Cause_Dict[] = {
         "User-Request",
         "Lost-Carrier",
         "Lost-Service",
@@ -22,7 +22,7 @@ char* RAD_Attr_Acct_Terminate_Cause_Dict[] = {
         "Host-Request",
 };
 
-char* RAD_Attr_Acct_Status_Type_Dict[] = {
+const char* RAD_Attr_Acct_Status_Type_Dict[] = {
         "Start",
         "Stop",
         "Interim-Update",

--- a/raddict.h
+++ b/raddict.h
@@ -1,0 +1,40 @@
+#ifndef RAD_DICT
+#define RAD_DICT
+
+char* RAD_Attr_Acct_Terminate_Cause_Dict[] = {
+        "User-Request",
+        "Lost-Carrier",
+        "Lost-Service",
+        "Idle-Timeout",
+        "Session-Timeout",
+        "Admin-Reset",
+        "Admin-Reboot",
+        "Port-Error",
+        "NAS-Error",
+        "NAS-Request",
+        "NAS-Reboot",
+        "Port-Unneeded",
+        "Port-Preempted",
+        "Port-Suspended",
+        "Service-Unavailable",
+        "Callback",
+        "User-Error",
+        "Host-Request",
+};
+
+char* RAD_Attr_Acct_Status_Type_Dict[] = {
+        "Start",
+        "Stop",
+        "Interim-Update",
+        [7] = "Accounting-On",
+        [8] = "Accounting-Off",
+        [9] = "Tunnel-Start",
+        [10] = "Tunnel-Stop",
+        [11] = "Tunnel-Reject",
+        [12] = "Tunnel-Link-Start",
+        [13] = "Tunnel-Link-Stop",
+        [14] = "Tunnel-Link-Reject",
+        [15] = "Failed",
+};
+
+#endif

--- a/radmsg.c
+++ b/radmsg.c
@@ -15,6 +15,7 @@
 #include <pthread.h>
 #include <nettle/hmac.h>
 #include <openssl/rand.h>
+#include "raddict.h"
 
 #define RADLEN(x) ntohs(((uint16_t *)(x))[1])
 
@@ -412,6 +413,24 @@ int resizeattr(struct tlv *attr, uint8_t newlen) {
     if (resizetlv(attr, newlen))
         return 1;
     return 0;
+}
+
+char* attrval2str(struct tlv *attr) {
+    if(!attr) return '\0';
+    uint32_t val = tlv2longint(attr) - 1;
+    switch (attr->t) {
+        case RAD_Attr_Acct_Status_Type:
+            return RAD_Attr_Acct_Status_Type_Dict[val] ? RAD_Attr_Acct_Status_Type_Dict[val] : RAD_Dict_Unknown_Value;
+            break;
+
+        case RAD_Attr_Acct_Terminate_Cause:
+            return RAD_Attr_Acct_Terminate_Cause_Dict[val] ? RAD_Attr_Acct_Terminate_Cause_Dict[val] : RAD_Dict_Unknown_Value;
+            break;
+
+        default:
+            break;
+    }
+    return RAD_Dict_Unknown_Value;
 }
 
 /* Local Variables: */

--- a/radmsg.c
+++ b/radmsg.c
@@ -420,17 +420,19 @@ char* attrval2str(struct tlv *attr) {
     uint32_t val = tlv2longint(attr) - 1;
     switch (attr->t) {
         case RAD_Attr_Acct_Status_Type:
-            return RAD_Attr_Acct_Status_Type_Dict[val] ? RAD_Attr_Acct_Status_Type_Dict[val] : RAD_Dict_Unknown_Value;
+            if(val < sizeof(RAD_Attr_Acct_Status_Type_Dict)/sizeof(uint32_t))
+                return RAD_Attr_Acct_Status_Type_Dict[val] ? strdup(RAD_Attr_Acct_Status_Type_Dict[val]) : strdup(RAD_Dict_Unknown_Value);
             break;
 
         case RAD_Attr_Acct_Terminate_Cause:
-            return RAD_Attr_Acct_Terminate_Cause_Dict[val] ? RAD_Attr_Acct_Terminate_Cause_Dict[val] : RAD_Dict_Unknown_Value;
+            if(val < sizeof(RAD_Attr_Acct_Terminate_Cause_Dict)/sizeof(uint32_t))
+                return RAD_Attr_Acct_Terminate_Cause_Dict[val] ? strdup(RAD_Attr_Acct_Terminate_Cause_Dict[val]) : strdup(RAD_Dict_Unknown_Value);
             break;
 
         default:
             break;
     }
-    return RAD_Dict_Unknown_Value;
+    return strdup(RAD_Dict_Unknown_Value);
 }
 
 /* Local Variables: */

--- a/radmsg.h
+++ b/radmsg.h
@@ -21,16 +21,38 @@
 #define RAD_Attr_User_Name 1
 #define RAD_Attr_User_Password 2
 #define RAD_Attr_CHAP_Password 3
+#define RAD_Attr_NAS_IP_Address 4
+#define RAD_Attr_Framed_IP_Address 8
 #define RAD_Attr_Reply_Message 18
 #define RAD_Attr_Vendor_Specific 26
+#define RAD_Attr_Called_Station_Id 30
 #define RAD_Attr_Calling_Station_Id 31
 #define RAD_Attr_Proxy_State 33
 #define RAD_Attr_CHAP_Challenge 60
 #define RAD_Attr_Tunnel_Password 69
 #define RAD_Attr_Message_Authenticator 80
+#define RAD_Attr_Acct_Status_Type 40
+#define RAD_Attr_Acct_Input_Octets 42
+#define RAD_Attr_Acct_Output_Octets 43
+#define RAD_Attr_Acct_Session_Id 44
+#define RAD_Attr_Acct_Session_Time 46
+#define RAD_Attr_Acct_Input_Packets 47
+#define RAD_Attr_Acct_Output_Packets 48
+#define RAD_Attr_Acct_Terminate_Cause 49
+#define RAD_Attr_Event_Timestamp 55
+
+#define RAD_Acct_Status_Start 1
+#define RAD_Acct_Status_Stop 2
+#define RAD_Acct_Status_Alive 3
+#define RAD_Acct_Status_Interim_Update 3
+#define RAD_Acct_Status_Accounting_On 7
+#define RAD_Acct_Status_Accounting_Off 8
+#define RAD_Acct_Status_Failed 15
 
 #define RAD_VS_ATTR_MS_MPPE_Send_Key 16
 #define RAD_VS_ATTR_MS_MPPE_Recv_Key 17
+
+#define RAD_Dict_Unknown_Value "UNKNOWN"
 
 struct radmsg {
     uint8_t code;
@@ -60,6 +82,7 @@ int vattrname2val(char *attrname, uint32_t *vendor, uint32_t *type);
 int attrvalidate(unsigned char *attrs, int length);
 struct tlv *makevendortlv(uint32_t vendor, struct tlv *attr);
 int resizeattr(struct tlv *attr, uint8_t newlen);
+char* attrval2str(struct tlv *attr);
 
 #endif /*_RADMSG_H*/
 

--- a/tlv11.c
+++ b/tlv11.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2010, NORDUnet A/S */
 /* See LICENSE for licensing information. */
 
+#define _GNU_SOURCE
 #ifdef SYS_SOLARIS9
 #include <sys/inttypes.h>
 #else
@@ -12,6 +13,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <arpa/inet.h>
+#include <stdio.h>
 
 struct tlv *maketlv(uint8_t t, uint8_t l, void *v) {
     struct tlv *tlv;
@@ -97,6 +99,8 @@ void rmtlv(struct list *tlvs, uint8_t t) {
 }
 
 uint8_t *tlv2str(struct tlv *tlv) {
+    if(!tlv)
+        return '\0';
     uint8_t *s = malloc(tlv->l + 1);
     if (s) {
 	memcpy(s, tlv->v, tlv->l);
@@ -115,6 +119,30 @@ struct tlv *resizetlv(struct tlv *tlv, uint8_t newlen) {
         tlv->l = newlen;
     }
     return tlv;
+}
+
+uint32_t tlv2longint(struct tlv *tlv) {
+    if(!tlv) return 0;
+    uint32_t n = 0;
+    n += tlv->v[3];
+    n += tlv->v[2] << 8;
+    n += tlv->v[1] << 16;
+    n += tlv->v[0] << 24;
+    return n;
+}
+
+char* tlv2ipv4addr(struct tlv *tlv) {
+    if(!tlv) return 0;
+    char *rval = "undef";
+    if(tlv->v) {
+        uint8_t *v = tlv2str(tlv);
+	char *str;
+        if(asprintf(&str, "%d.%d.%d.%d", v[0], v[1], v[2], v[3]) >=0) {
+            rval = str;
+        }
+        free(v);
+    }
+    return rval;
 }
 
 /* Local Variables: */

--- a/tlv11.h
+++ b/tlv11.h
@@ -17,6 +17,8 @@ void freetlvlist(struct list *);
 void rmtlv(struct list *, uint8_t);
 uint8_t *tlv2str(struct tlv *tlv);
 struct tlv *resizetlv(struct tlv *, uint8_t);
+uint32_t tlv2longint(struct tlv *tlv);
+char* tlv2ipv4addr(struct tlv *tlv);
 
 /* Local Variables: */
 /* c-file-style: "stroustrup" */


### PR DESCRIPTION
This PR will log incoming Accounting-Request packets at log level NOTICE if `AccountingResponse` is set to `on`.

It's a fixed format of logging and only currently supports some RADIUS attributes/values but it's a start!

I'm happy to take suggestions for changes and functionality.