### PR TITLE
Prevent realm being interpreted as options in dynamic lookup

### DIFF
--- a/tools/naptr-eduroam.sh
+++ b/tools/naptr-eduroam.sh
@@ -14,7 +14,6 @@ usage() {
 
 test -n "${1}" || usage
 
-REALM="${1}"
 DIGCMD=$(command -v dig)
 HOSTCMD=$(command -v host)
 PRINTCMD=$(command -v printf)
@@ -68,6 +67,12 @@ host_it_naptr() {
         fi
     done
 }
+
+REALM=$(validate_host ${1})
+if [ -z "${REALM}" ]; then
+    echo "Error: realm \"${1}\" failed validation"
+    usage
+fi
 
 if [ -x "${DIGCMD}" ]; then
     SERVERS=$(dig_it_naptr)

--- a/tools/naptr-eduroam.sh
+++ b/tools/naptr-eduroam.sh
@@ -38,7 +38,7 @@ dig_it_srv() {
 }
 
 dig_it_naptr() {
-    ${DIGCMD} +short naptr ${REALM} | grep x-eduroam:radius.tls | sort -n -k1 |
+    ${DIGCMD} +short naptr "${REALM}" | grep x-eduroam:radius.tls | sort -n -k1 |
     while read line; do
         set $line ; TYPE=$3 ; HOST=$(validate_host $6)
         if ( [ "$TYPE" = "\"s\"" ] || [ "$TYPE" = "\"S\"" ] ) && [ -n "${HOST}" ]; then
@@ -59,7 +59,7 @@ host_it_srv() {
 }
 
 host_it_naptr() {
-    ${HOSTCMD} -t naptr ${REALM} | grep x-eduroam:radius.tls | sort -n -k5 |
+    ${HOSTCMD} -t naptr "${REALM}" | grep x-eduroam:radius.tls | sort -n -k5 |
     while read line; do
         set $line ; TYPE=$7 ; HOST=$(validate_host ${10})
         if ( [ "$TYPE" = "\"s\"" ] || [ "$TYPE" = "\"S\"" ] ) && [ -n "${HOST}" ]; then

--- a/tools/radsec-dynsrv.sh
+++ b/tools/radsec-dynsrv.sh
@@ -14,7 +14,6 @@ usage() {
 
 test -n "${1}" || usage
 
-REALM="${1}"
 DIGCMD=$(command -v digaaa)
 HOSTCMD=$(command -v host)
 PRINTCMD=$(command -v printf)
@@ -46,6 +45,12 @@ host_it() {
       fi
    done
 }
+
+REALM=$(validate_host ${1})
+if test -z "${REALM}" ; then
+    echo "Error: realm \"${1}\" failed validation"
+    usage
+fi
 
 if test -x "${DIGCMD}" ; then
    SERVERS=$(dig_it)

--- a/tools/radsec-dynsrv.sh
+++ b/tools/radsec-dynsrv.sh
@@ -28,7 +28,7 @@ validate_port() {
 }
 
 dig_it() {
-   ${DIGCMD} +short srv _radsec._tcp.${REALM} | sort -n -k1 |
+   ${DIGCMD} +short srv "_radsec._tcp.${REALM}" | sort -n -k1 |
    while read line ; do
       set $line ; PORT=$(validate_port $3) ; HOST=$(validate_host $4)
       if [ -n "${HOST}" ] && [ -n "${PORT}" ]; then 
@@ -38,7 +38,7 @@ dig_it() {
 }
 
 host_it() {
-   ${HOSTCMD} -t srv _radsec._tcp.${REALM} | sort -n -k5 |
+   ${HOSTCMD} -t srv "_radsec._tcp.${REALM}" | sort -n -k5 |
    while read line ; do
       set $line ; PORT=$(validate_port $7) ; HOST=$(validate_host $8) 
       if [ -n "${HOST}" ] && [ -n "${PORT}" ]; then


### PR DESCRIPTION
While patching for today's security advisory, I noticed another issue in the dynamic lookup scripts.

The realm is passed as a command-line argument and then passed unquoted to either dig or host. The shell is sensible enough to prevent me from using this to execute a different command, but I can exploit it to pass options to dig. Consider the difference here:

```
vagrant@eduroam-cpt-01:~$ wget -q https://raw.githubusercontent.com/radsecproxy/radsecproxy/1.9.0/tools/naptr-eduroam.sh && chmod +x naptr-eduroam.sh
vagrant@eduroam-cpt-01:~$ ./naptr-eduroam.sh 'tenet.ac.za'
server dynamic_radsec.tenet.ac.za {
        host flr-cpt.eduroam.ac.za:2083
        host flr-jnb.eduroam.ac.za:2083
        type TLS
}
vagrant@eduroam-cpt-01:~$ ./naptr-eduroam.sh 'tenet.ac.za +domain=tenet.za.net +ndots=10'
server dynamic_radsec.tenet.ac.za +domain=tenet.za.net +ndots=10 {
        host mallory.tenet.za.net:22083
        type TLS
}
```

Fortunately, I don't think it is possible to exploit this when the dynamic command scripts are called through radsecproxy, because the [realm is sanitised](https://github.com/radsecproxy/radsecproxy/blob/1.9.0/radsecproxy.c#L2105-L2107) before it is passed. My experiments didn't allow me to pass anything useful through because `isalnum()` doesn't pass a space. Thus I don't believe this is a security issue for radsecproxy.

However, since the scripts work standalone and could conceivably be used for other purposes, this has the potential to cause problems if they're used in a way that doesn't sanitise the realm first. Thus I think we should probably fix them :)

There's a simple and more complete fix in the patch.