### PR TITLE
Mention how to install radsecproxy on EPEL

### DIFF
--- a/README
+++ b/README
@@ -8,11 +8,12 @@ flexible, while at the same time to be small, efficient and easy to configure.
 Official packages are available:
 
 Debian: apt-get install radsecproxy
+CentOS/RHEL/Rocky: yum install epel-release; yum install radsecproxy
 Fedora: dnf install radsecproxy
 FreeBSD: pkg install radsecproxy
 NetBSD: pkgin install radsecproxy
 
-Or built it from this rouce on most Unix like systems by simply typing
+Or built it from this source on most Unix like systems by simply typing
 
     ./configure && make
 


### PR DESCRIPTION
While Fedora EPEL is indeed not the official source for CentOS/RHEL/Rocky Linux, it's likely the most prominent, most used and a very well known third-party repository out there. As a Fedora/EPEL package maintainer my intention is to apply the same quality for EPEL packages like for Fedora packages. The usage of `yum` rather `dnf` is explicitly suggested because CentOS/RHEL 7 is still often used.

P.S.: Minor fix for a typo