### PR TITLE
Fix Message-Authenticator calculation on accounting packets to be freeradius compatible

### DIFF
--- a/radmsg.h
+++ b/radmsg.h
@@ -55,8 +55,8 @@ int radmsg_copy_attrs(struct radmsg *dst,
                       const struct radmsg *src,
                       uint8_t type);
 uint8_t *tlv2buf(uint8_t *p, const struct tlv *tlv);
-uint8_t *radmsg2buf(struct radmsg *msg, uint8_t *, int);
-struct radmsg *buf2radmsg(uint8_t *, uint8_t *, int, uint8_t *);
+uint8_t *radmsg2buf(struct radmsg *msg, uint8_t *, int, uint8_t);
+struct radmsg *buf2radmsg(uint8_t *, uint8_t *, int, uint8_t, uint8_t *);
 uint8_t attrname2val(char *attrname);
 int vattrname2val(char *attrname, uint32_t *vendor, uint32_t *type);
 int attrvalidate(unsigned char *attrs, int length);

--- a/radsecproxy.h
+++ b/radsecproxy.h
@@ -115,6 +115,7 @@ struct request {
     struct client *from;
     struct server *to;
     char *origusername;
+    uint8_t rqcode;
     uint8_t rqid;
     uint8_t rqauth[16];
     uint8_t newid;


### PR DESCRIPTION
Moin,

We have a radius client implementation that also creates (and verifies) Message-Authenticator attributes on Accounting packets, in the same way that freeradius v3 supports them.

In the process of replacing some VPN links with certificate based radsec instead we start to use radsecproxy on the client side, connecting to our previously existing freeradius servers now using radsec, instead of direct UDP packets from the clients through VPN to the freeradius.

In this I found that radsecproxy rejects our radius clients accounting messages, with "message authenticator, wrong value", for packets that contain the Message-Authenticator that freeradius expects for them.

Checking the radsecproxy code I discovered that it does not implement the slightly different handling needed to calculate this header for accounting - and this is what this PR adds.

For the normal majority of accounting packets that do not contain any Message-Authenticator attribute (as it is not really needed there, because the request/response authenticator already does basically the same), nothing changes with the patch.

Greetings,
Haegar
