### PR TITLE
Add ServerName configuration option for certificate name check and SNI

### DIFF
--- a/dtls.c
+++ b/dtls.c
@@ -616,6 +616,7 @@ int dtlsconnect(struct server *server, int timeout, char *text) {
             if (server->conf->sni) {
                 struct in6_addr tmp;
                 char *servername = server->conf->sniservername ? server->conf->sniservername : 
+                    server->conf->servername ? server->conf->servername :
                     (inet_pton(AF_INET, hp->host, &tmp) || inet_pton(AF_INET6, hp->host, &tmp)) ? NULL : hp->host;
                 if (servername && !tlssetsni(server->ssl, servername)) {
                     debug(DBG_ERR, "tlsconnect: set SNI %s failed", servername);

--- a/radsecproxy.c
+++ b/radsecproxy.c
@@ -2426,6 +2426,7 @@ int confclient_cb(struct gconffile **cf, void *arg, char *block, char *opt, char
 	    "tls", CONF_STR, &conf->tls,
 	    "MatchCertificateAttribute", CONF_MSTR, &matchcertattrs,
 	    "CertificateNameCheck", CONF_BLN, &conf->certnamecheck,
+	    "ServerName", CONF_STR, &conf->servername,
 #endif
 	    "DuplicateInterval", CONF_LINT, &dupinterval,
 	    "addTTL", CONF_LINT, &addttl,
@@ -2642,6 +2643,7 @@ int confserver_cb(struct gconffile **cf, void *arg, char *block, char *opt, char
             "tls", CONF_STR, &conf->tls,
             "MatchCertificateAttribute", CONF_MSTR, &conf->confmatchcertattrs,
             "CertificateNameCheck", CONF_BLN, &conf->certnamecheck,
+            "ServerName", CONF_STR, &conf->servername,
 #endif
             "addTTL", CONF_LINT, &addttl,
             "tcpKeepalive", CONF_BLN, &conf->keepalive,

--- a/radsecproxy.c
+++ b/radsecproxy.c
@@ -2270,6 +2270,7 @@ void freeclsrvconf(struct clsrvconf *conf) {
     free(conf->confrewritein);
     free(conf->confrewriteout);
     free(conf->sniservername);
+    free(conf->servername);
     if (conf->rewriteusername) {
 	if (conf->rewriteusername->regex)
 	    regfree(conf->rewriteusername->regex);
@@ -2364,7 +2365,8 @@ int mergesrvconf(struct clsrvconf *dst, struct clsrvconf *src) {
 	!mergeconfstring(&dst->dynamiclookupcommand, &src->dynamiclookupcommand) ||
 	!mergeconfstring(&dst->fticks_viscountry, &src->fticks_viscountry) ||
 	!mergeconfstring(&dst->fticks_visinst, &src->fticks_visinst) ||
-    !mergeconfstring(&dst->sniservername, &src->sniservername))
+    !mergeconfstring(&dst->sniservername, &src->sniservername) ||
+    !mergeconfstring(&dst->servername, &src->servername))
 	return 0;
     if (src->pdef)
 	dst->pdef = src->pdef;

--- a/radsecproxy.conf.5.in
+++ b/radsecproxy.conf.5.in
@@ -416,6 +416,12 @@ exist, or the option is not specified and none of the defaults exist, the proxy
 will exit with an error.
 .RE
 
+.BI "ServerName " server_name
+.RS
+Instead of the definition in \fBHost\fR, use \fIserver_name\fR for the
+certificate name check.
+.RE
+
 .BR "CertificateNameCheck (" on | off )
 .RS
 For a TLS/DTLS client, disable the default behaviour of matching CN or
@@ -552,6 +558,13 @@ default to 1812 while TLS and DTLS will default to 2083.
 .RS
 Specify the source address and/or port to use for this server. See \fBSource...\fR 
 options above.
+.RE
+
+.BI "ServerName " server_name
+.RS
+Instead of the definition in \fBHost\fR, use \fIserver_name\fR for the
+certificate name check. Additionally, this name is used for SNI, unless
+\fBSNIservername\fR is set.
 .RE
 
 .BI "DynamicLookupCommand " command

--- a/radsecproxy.h
+++ b/radsecproxy.h
@@ -141,6 +141,7 @@ struct clsrvconf {
     uint8_t type; /* RAD_UDP/RAD_TLS/RAD_TCP */
     const struct protodefs *pdef;
     char **hostsrc;
+    char *servername;
     int hostaf;
     char *portsrc;
     struct list *hostports;

--- a/tls.c
+++ b/tls.c
@@ -168,6 +168,7 @@ int tlsconnect(struct server *server, int timeout, char *text) {
             if (server->conf->sni) {
                 struct in6_addr tmp;
                 char *servername = server->conf->sniservername ? server->conf->sniservername : 
+                    server->conf->servername ? server->conf->servername :
                     (inet_pton(AF_INET, hp->host, &tmp) || inet_pton(AF_INET6, hp->host, &tmp)) ? NULL : hp->host;
                 if (servername && !tlssetsni(server->ssl, servername)) {
                     debug(DBG_ERR, "tlsconnect: set SNI %s failed", servername);

--- a/tlscommon.c
+++ b/tlscommon.c
@@ -798,7 +798,19 @@ int verifyconfcert(X509 *cert, struct clsrvconf *conf, struct hostportres *hpcon
     debug(DBG_DBG, "verifyconfcert: verify certificate for host %s, subject %s", conf->name, subject);
     if (conf->certnamecheck) {
         debug(DBG_DBG, "verifyconfcert: verify hostname");
-        if (hpconnected) {
+        if (conf->servername) {
+            struct hostportres *servername = malloc(sizeof(struct hostportres));
+            servername->host = conf->servername;
+            servername->addrinfo = NULL;
+            servername->port = NULL;
+            servername->prefixlen = 255;
+            if (!certnamecheck(cert, servername)){
+                debug(DBG_WARN, "verifyconfcert: certificate name check failed for host %s (%s)", conf->name, servername->host);
+                ok = 0;
+            }
+            free(servername);
+        }
+        else if (hpconnected) {
             if (!certnamecheck(cert, hpconnected)) {
                 debug(DBG_WARN, "verifyconfcert: certificate name check failed for host %s (%s)", conf->name, hpconnected->host);
                 ok = 0;


### PR DESCRIPTION
This PR adds the configuration option `ServerName` in the `client` and `server` sections

The option has the following behavior:
* If set, the certificate name check will check against the value of `ServerName` instead of `Host`
* For server blocks, if SNI is enabled, the value of `ServerName` is used, unless the more specific `SNIservername` is set.

Especially the first behavior is extremely useful in settings where IP addresses are used in the `Host` option to avoid blocking startup due to DNS issues.
With the current setting it is necessary to disable the CertificateNameCheck and provide an own MatchCertificateAttribute with a Regex.
This PR helps with the definition since it does not need to deal with regex and automatically uses both SAN and CN for the check.

(Example for dealing with regex: `/^tld1.example\.com$/` is also valid for a cert for `tld1-example.com` due to the unescaped first dot. And those config errors are hard to spot)

~~I have not done excessive testing of edge cases in the certificate validation yet, hence the WIP-status, but basic test cases work.~~
Update: I have now rebased to the current master, checked the code again and haven't found any issues, so I would say that this PR is ready now.
Feedback welcome.