### PR TITLE
Fix uninitialized value (found by valgrind)

### DIFF
--- a/udp.c
+++ b/udp.c
@@ -267,7 +267,7 @@ int clientradputudp(struct server *server, unsigned char *rad, int radlen) {
 
 void *udpclientrd(void *arg) {
     struct server *server;
-    unsigned char *buf;
+    unsigned char *buf = NULL;
     int *s = (int *)arg;
     int len = 0;
 


### PR DESCRIPTION
I found this issue when running the current master with valgrind.

Valgrind message:
Conditional jump or move depends on uninitialised value(s)

The value of `buf` is used in the function `radudpget` (see `udp.c:151`), this value may be uninitialized when creating the pointer in `udpclientrd` (see `udp.c:270`)