### PR TITLE
Feature for Subrealm regex

### DIFF
--- a/radsecproxy.c
+++ b/radsecproxy.c
@@ -2245,27 +2245,65 @@ void freerealm(struct realm *realm) {
     free(realm);
 }
 
-struct realm *addrealm(struct list *realmlist, char *value, char **servers, char **accservers, char *message, uint8_t accresp, uint8_t acclog) {
-    int n;
+struct realm *addrealm(struct list *realmlist, char *value, enum rsp_subrealm subrealm_policy, char **servers, char **accservers, char *message, uint8_t accresp, uint8_t acclog) {
+    int n, add_r;
     struct realm *realm;
     char *s, *regex = NULL;
 
     if (*value == '/') {
-        /* regexp, remove optional trailing / if present */
+        /* config for realm is a regexp */
+        /* Check for subrealm config and warn if present */
+        if (subrealm_policy != RSP_SUBREALM_NO)
+            debug(DBG_WARN, "addrealm: the realm was a regex, but a subrealm config was found. Ignoring subrealm config.");
+        /* remove optional trailing '/' if present */
         if (value[strlen(value) - 1] == '/')
             value[strlen(value) - 1] = '\0';
     } else {
         /* not a regexp, let us make it one */
-        if (*value == '*' && !value[1])
+        /* First check if this is a wildcard realm */
+        if (*value == '*' && !value[1]) {
             regex = stringcopy(".*", 0);
-        else {
+            if (subrealm_policy != RSP_SUBREALM_NO)
+                debug(DBG_WARN, "addrealm: got wildcard realm config, but a subrealm config was found. Ignoring subrealm config, because wildcard already includes all subrealms.");
+        } else {
+            /* First, count the number of dots (because we need to add escaping) */
             for (n = 0, s = value; *s;)
                 if (*s++ == '.')
                     n++;
-            regex = malloc(strlen(value) + n + 3);
+            /* Depending on the subrealm policy, we need different additional regex lengths */
+            switch (subrealm_policy) {
+            case RSP_SUBREALM_NO:
+                add_r = 0;
+                break;
+            case RSP_SUBREALM_INCLUDE:
+                add_r = strlen(RAD_REALM_REGEX_SUBREALM_INCLUDE);
+                break;
+            case RSP_SUBREALM_ONLY:
+                add_r = strlen(RAD_REALM_REGEX_SUBREALM_ONLY);
+                break;
+            default:
+                debug(DBG_ERR, "addrealm: invalid subrealm policy");
+                realm = NULL;
+                goto exit;
+            }
+            /* Allocate enough memory: original length, escaping of dots (n), general regex additions (3) and optional subrealm addition (add_r) */
+            regex = malloc(strlen(value) + n + 3 + add_r);
             if (regex) {
                 regex[0] = '@';
-                for (n = 1, s = value; *s; s++) {
+                n = 1;
+                switch (subrealm_policy) {
+                case RSP_SUBREALM_INCLUDE:
+                    strcpy(regex + 1, RAD_REALM_REGEX_SUBREALM_INCLUDE);
+                    n += strlen(RAD_REALM_REGEX_SUBREALM_INCLUDE);
+                    break;
+                case RSP_SUBREALM_ONLY:
+                    strcpy(regex + 1, RAD_REALM_REGEX_SUBREALM_ONLY);
+                    n += strlen(RAD_REALM_REGEX_SUBREALM_ONLY);
+                    break;
+                default:
+                    break;
+                }
+                for (s = value; *s; s++) {
                     if (*s == '.')
                         regex[n++] = '\\';
                     regex[n++] = *s;
@@ -2416,7 +2454,7 @@ struct realm *adddynamicrealmserver(struct realm *realm, char *id) {
     if (!realm->subrealms)
         return NULL;
 
-    newrealm = addrealm(realm->subrealms, realmname, NULL, NULL, stringcopy(realm->message, 0), realm->accresp, realm->acclog);
+    newrealm = addrealm(realm->subrealms, realmname, RSP_SUBREALM_NO, NULL, NULL, stringcopy(realm->message, 0), realm->accresp, realm->acclog);
     if (!newrealm) {
         list_destroy(realm->subrealms);
         realm->subrealms = NULL;
@@ -3322,12 +3360,13 @@ int confrewrite_cb(struct gconffile **cf, void *arg, char *block, char *opt, cha
 }
 
 int confrealm_cb(struct gconffile **cf, void *arg, char *block, char *opt, char *val) {
-    char **servers = NULL, **accservers = NULL, *msg = NULL;
-    uint8_t accresp = 0, acclog = 0;
+    char **servers = NULL, **accservers = NULL, *msg = NULL, *subrealms = NULL;
+    uint8_t accresp = 0, acclog = 0, subrealm_policy = 0;
 
     debug(DBG_DBG, "confrealm_cb called for %s", block);
 
     if (!getgenericconfig(cf, block,
+                          "subrealms", CONF_STR, &subrealms,
                           "server", CONF_MSTR, &servers,
                           "accountingServer", CONF_MSTR, &accservers,
                           "ReplyMessage", CONF_STR, &msg,
@@ -3336,7 +3375,17 @@ int confrealm_cb(struct gconffile **cf, void *arg, char *block, char *opt, char 
                           NULL))
         debugx(1, DBG_ERR, "configuration error");
 
-    if (!addrealm(realms, val, servers, accservers, msg, accresp, acclog)) {
+    if ((subrealms == NULL) || strcasecmp(subrealms, "No") == 0) {
+        subrealm_policy = RSP_SUBREALM_NO;
+    } else if (strcasecmp(subrealms, "Include") == 0) {
+        subrealm_policy = RSP_SUBREALM_INCLUDE;
+    } else if (strcasecmp(subrealms, "Only") == 0) {
+        subrealm_policy = RSP_SUBREALM_ONLY;
+    } else {
+        debugx(1, DBG_ERR, "Invalid configuration for subrealms in realm block %s: %s is not a valid option", val, subrealms);
+    }
+
+    if (!addrealm(realms, val, subrealm_policy, servers, accservers, msg, accresp, acclog)) {
         debug(DBG_ERR, "failed to add %s", block);
         return 0;
     }

--- a/radsecproxy.conf.5.in
+++ b/radsecproxy.conf.5.in
@@ -832,6 +832,17 @@ found.
 
 The allowed options in a realm block are:
 
+.BI "Subrealms (" No | Include | Only )
+.RS
+For non-regex realms, determine if the realm should be matched exactly
+(\fBSubrealms No\fR), if subrealms should be included (\fBSubrealms Include\fR)
+or if this realm block should only apply to subrealms of the given realm
+(\fBSubrealms Only\fR). \fBSubrealms No\fR is the default. If this option is set
+in regex- or wildcard realm blocks, it is ignored and a warning is issued. See
+the \fBREALM BLOCK NAMES AND MATCHING\fR section below for further information
+on possible use cases.
+.RE
+
 .BI "Server " server
 .br
 .BI "AccountingServer " server
@@ -887,6 +898,14 @@ the matching is done on the entire attribute value, you can also use rules like
 /^[a\-k].*@example\e.com$/ to get some of the users in this domain to use one
 server, while other users could be matched by another realm block and use
 another server.
+
+The configuration option \fBSubrealms\fR allows for an additional, more
+foolproof handling of realms than regex matching.  With this option, you can
+specify whether subrealms of the given realm should also be treated the same.
+The option \fBSubrealms Only\fR, for example, allows for a realm block where all
+subdomain requests for the given realm are rejected. This is especially helpful
+when dynamic lookup in connection with a default routing path is used, but only
+the primary domain is actually routed.
 
 .SS "SERVER SELECTION"
 

--- a/radsecproxy.h
+++ b/radsecproxy.h
@@ -58,6 +58,10 @@
 #define RAD_DTLS 3
 #define RAD_PROTOCOUNT 4
 
+/* Define the Regex prefixes for the different subrealm configurations */
+#define RAD_REALM_REGEX_SUBREALM_ONLY "[^@]*\\."
+#define RAD_REALM_REGEX_SUBREALM_INCLUDE "([^@]*\\.)?"
+
 enum rsp_fticks_reporting_type {
     RSP_FTICKS_REPORTING_NONE = 0, /* Default.  */
     RSP_FTICKS_REPORTING_BASIC,
@@ -86,6 +90,12 @@ enum rsp_statsrv {
     RSP_STATSRV_ON,
     RSP_STATSRV_MINIMAL,
     RSP_STATSRV_AUTO
+};
+
+enum rsp_subrealm {
+    RSP_SUBREALM_NO = 0,
+    RSP_SUBREALM_INCLUDE,
+    RSP_SUBREALM_ONLY
 };
 
 struct options {


### PR DESCRIPTION
With this change, a new config option `Subrealms` is introduced into the `realm` config block.

The idea is to allow for a much cleaner configuration file without to many regexes, which are prone to human error in many ways. (Forgetting backslash before dot, inaccurate matching groups, not easy to read and understand, ...)

Instead of cumbersomely writing `realm /@([^@]*\.)?example\.com$/` to match the realm together with all sub-realms, you now can simply write
```
realm example.com {
  Subrealms Include
  server my-example-server
  [...]
}
```

Since non-regex realm configurations are internally converted to regexes anyway, this configuration option is just a shortcut.
The given options are:
* `No` : Default, Same behavior as before (`example.com` -> `@example\.com`)
* `Include` : Include all subrealms, as well as the base realms (`example.com` -> `@([^@]*\.)?example\.com`)
* `Only` : Include only subrealms, but not the base realm (`example.com` -> `@[^@]*\.example\.com`)

Anoter goal of this patch is to fix some dynamic lookup problems.
Especially with a default route, dynamic lookups can cause loops if subrealms are not specified explicitly, but due to a NAPTR records, they are routed to the own server by the upstream server.
A working, simple configuration could look like this:
```
realm example.com {
  server my-example-server
}
realm example.com {
  Subrealms Only
  replymessage "Subrealms of example.com are not routed!"
}
realm * {
  server my-upstream-server
}
```

Edit:
I've previously included two open points, but after looking at it again, I think it is irrelevant.