### PR TITLE
The most basic changes to make radsecproxy speak Windows

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -184,6 +184,12 @@ not `/usr/local'.  It is recommended to use the following options:
 
      ./configure --prefix=/boot/common
 
+   On Windows, use Cygwin for best results.  While this introduces 
+dependencies on several Cygwin DLLs, these are easily summarised by using
+the Dependency Walker utility.  We also recommend building radsecproxy 
+with an installation prefix other than `/usr/local' by giving
+`configure' the option `--prefix=PREFIX'.
+
 Specifying the System Type
 ==========================
 

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-This is radsecproxy 1.10.0
+This is radsecproxy 1.11.0
 
 radsecproxy is a generic RADIUS proxy that supports both UDP and TLS
 (RadSec) RADIUS transports.  There is also experimental support for
@@ -13,7 +13,7 @@ Fedora: dnf install radsecproxy
 FreeBSD: pkg install radsecproxy
 NetBSD: pkgin install radsecproxy
 
-Or built it from this source on most Unix like systems by simply typing
+Or build it from this source on most Unix like systems by simply typing
 
     ./configure && make
 
@@ -25,6 +25,10 @@ the location with the "-c" command line option (see below).  For further
 instructions, please see the enclosed example file and the manpages
 radsecproxy(8) and radsecproxy.conf(5).
 
-Note for Cygwin users:
-Due to a bug in openssl the tls option CACertificatePath is currently unusable.
-Use a certificate bundle with CACertificateFile instead.
+Notes for Cygwin users:
+- Due to a bug in openssl the tls option CACertificatePath is currently unusable.
+  Use a certificate bundle with CACertificateFile instead.
+- In newer versions of Cygwin, certain function calls to make internal dynamic peer 
+  discovery work are not available in libresolv (the linker complains). The internal 
+  dynamic peer discovery has been disabled and you're limited to static definitions 
+  or an external script.

--- a/debug.c
+++ b/debug.c
@@ -204,9 +204,9 @@ void debug_logit(uint8_t level, const char *format, va_list ap) {
             strncpy(timebuf+24,": ", 3);
         }
 #ifdef __CYGWIN__
-        malloc_size = strlen(format) + (timebuf ? strlen(timebuf) : 0) + 4*sizeof(char);
+        malloc_size = strlen(format) + (timebuf ? strlen(timebuf) : 0) + 4 * sizeof(char);
 #else
-        malloc_size = strlen(format) + (timebuf ? strlen(timebuf) : 0) + 2*sizeof(char);
+        malloc_size = strlen(format) + (timebuf ? strlen(timebuf) : 0) + 2 * sizeof(char);
 #endif
         tmp2 = malloc(malloc_size);
         if (tmp2) {

--- a/debug.c
+++ b/debug.c
@@ -203,10 +203,18 @@ void debug_logit(uint8_t level, const char *format, va_list ap) {
             /*ctime_r writes exactly 24 bytes + "\n\0" */
             strncpy(timebuf+24,": ", 3);
         }
+#ifdef __CYGWIN__
+        malloc_size = strlen(format) + (timebuf ? strlen(timebuf) : 0) + 4*sizeof(char);
+#else
         malloc_size = strlen(format) + (timebuf ? strlen(timebuf) : 0) + 2*sizeof(char);
+#endif
         tmp2 = malloc(malloc_size);
         if (tmp2) {
+#ifdef __CYGWIN__
+            snprintf(tmp2, malloc_size, "%s%s\r\n", timebuf ? timebuf : "", format);
+#else
             snprintf(tmp2, malloc_size, "%s%s\n", timebuf ? timebuf : "", format);
+#endif
             format = tmp2;
         }
         vfprintf(debug_file, format, ap);

--- a/radsecproxy.c
+++ b/radsecproxy.c
@@ -34,48 +34,48 @@
  */
 
 #define _GNU_SOURCE
-#include <signal.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <netdb.h>
-#include <string.h>
-#include <unistd.h>
 #include <limits.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <signal.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
 #if defined(HAVE_MALLOPT)
 #include <malloc.h>
 #endif
-#ifdef SYS_SOLARIS9
+#ifdef SYS_SOLARIS
 #include <fcntl.h>
 #endif
-#include <sys/time.h>
-#include <sys/types.h>
-#include <ctype.h>
-#include <sys/wait.h>
-#include <arpa/inet.h>
-#include <regex.h>
-#include <libgen.h>
-#include <pthread.h>
-#include <errno.h>
-#include <assert.h>
-#include <poll.h>
-#include <openssl/ssl.h>
-#include <openssl/rand.h>
-#include <openssl/err.h>
-#include <nettle/md5.h>
 #include "debug.h"
-#include "hash.h"
-#include "util.h"
-#include "hostport.h"
-#include "radsecproxy.h"
-#include "udp.h"
-#include "tcp.h"
-#include "tls.h"
-#include "dtls.h"
-#include "fticks.h"
-#include "fticks_hashmac.h"
 #ifndef __CYGWIN__
 #include "dns.h"
 #endif
+#include "dtls.h"
+#include "fticks.h"
+#include "fticks_hashmac.h"
+#include "hash.h"
+#include "hostport.h"
+#include "radsecproxy.h"
+#include "tcp.h"
+#include "tls.h"
+#include "udp.h"
+#include "util.h"
+#include <arpa/inet.h>
+#include <assert.h>
+#include <ctype.h>
+#include <errno.h>
+#include <libgen.h>
+#include <nettle/md5.h>
+#include <openssl/err.h>
+#include <openssl/rand.h>
+#include <openssl/ssl.h>
+#include <poll.h>
+#include <pthread.h>
+#include <regex.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/wait.h>
 
 static struct options options;
 static struct list *clconfs, *srvconfs;
@@ -2355,10 +2355,10 @@ int dynamicconfig(struct server *server) {
 
     debug(DBG_DBG, "dynamicconfig: need dynamic server config for %s", server->dynamiclookuparg);
 #ifndef __CYGWIN__
-    if (strncasecmp(conf->dynamiclookupcommand, "naptr:", sizeof("naptr:")-1) == 0){
+    if (strncasecmp(conf->dynamiclookupcommand, "naptr:", sizeof("naptr:") - 1) == 0){
         result = dynamicconfignaptr(server);
     }
-    else if (strncasecmp(conf->dynamiclookupcommand, "srv:", sizeof("srv:")-1) == 0) {
+    else if (strncasecmp(conf->dynamiclookupcommand, "srv:", sizeof("srv:") - 1) == 0) {
         srvext = strchr(conf->dynamiclookupcommand, ':');
         if (!srvext) return 0;
         srvquery = malloc((strlen(srvext) + 1 + strlen(server->dynamiclookuparg) + 1) * sizeof(char));
@@ -2367,8 +2367,7 @@ int dynamicconfig(struct server *server) {
         
         result = dynamicconfigsrv(server, srvquery);
         free(srvquery);
-    }
-    else {
+    } else {
 #endif
         result = dynamicconfigexternal(server);
 #ifndef __CYGWIN__

--- a/radsecproxy.c
+++ b/radsecproxy.c
@@ -73,7 +73,9 @@
 #include "dtls.h"
 #include "fticks.h"
 #include "fticks_hashmac.h"
+#ifndef __CYGWIN__
 #include "dns.h"
+#endif
 
 static struct options options;
 static struct list *clconfs, *srvconfs;
@@ -2253,6 +2255,7 @@ int dynamicconfigexternal(struct server *server) {
     return ok;
 }
 
+#ifndef __CYGWIN__
 int dynamicconfigsrv(struct server *server, const char *srvstring) {
     struct clsrvconf *conf = server->conf;
     struct srv_record **srv;
@@ -2341,13 +2344,17 @@ int dynamicconfignaptr(struct server *server) {
     freenaptrresponse(naptr);
     return result;
 }
+#endif
 
 int dynamicconfig(struct server *server) {
+#ifndef __CYGWIN__
     struct clsrvconf *conf = server->conf;
     char *srvquery, *srvext;
+#endif
     int result = 0;
 
     debug(DBG_DBG, "dynamicconfig: need dynamic server config for %s", server->dynamiclookuparg);
+#ifndef __CYGWIN__
     if (strncasecmp(conf->dynamiclookupcommand, "naptr:", sizeof("naptr:")-1) == 0){
         result = dynamicconfignaptr(server);
     }
@@ -2362,8 +2369,11 @@ int dynamicconfig(struct server *server) {
         free(srvquery);
     }
     else {
+#endif
         result = dynamicconfigexternal(server);
+#ifndef __CYGWIN__
     }
+#endif
 
     if (!result)
         debug(DBG_WARN, "dynamicconfig: failed to obtain dynamic server config for %s", server->dynamiclookuparg);

--- a/radsecproxy.c
+++ b/radsecproxy.c
@@ -2357,8 +2357,7 @@ int dynamicconfig(struct server *server) {
 #ifndef __CYGWIN__
     if (strncasecmp(conf->dynamiclookupcommand, "naptr:", sizeof("naptr:") - 1) == 0){
         result = dynamicconfignaptr(server);
-    }
-    else if (strncasecmp(conf->dynamiclookupcommand, "srv:", sizeof("srv:") - 1) == 0) {
+    } else if (strncasecmp(conf->dynamiclookupcommand, "srv:", sizeof("srv:") - 1) == 0) {
         srvext = strchr(conf->dynamiclookupcommand, ':');
         if (!srvext) return 0;
         srvquery = malloc((strlen(srvext) + 1 + strlen(server->dynamiclookuparg) + 1) * sizeof(char));

--- a/radsecproxy.conf.5.in
+++ b/radsecproxy.conf.5.in
@@ -602,6 +602,7 @@ Execute the \fIcommand\fR to dynamically configure a server for a realm given by
 the username field in an Access-Request. 
 The command can take two special forms, naptr:\fIservice\fR or srv:\fIprefix\fR,
 or point to a script or executable.
+NOTE: When built on Cygwin for Windows, only the script or executable is currently available.
 
 The \fBnaptr:\fR and \fBsrv:\fR forms execute the corresponding DNS queries, either searching 
 for \fIservice\fR in NAPTR records (followed by SRV query), or querying for 

--- a/rewrite.c
+++ b/rewrite.c
@@ -45,7 +45,14 @@ struct tlv *extractattr(char *nameval, char vendor_flag) {
     }
 
     s++;
+#ifdef __CYGWIN__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wchar-subscripts"
+#endif
     if (isdigit(*s)) {
+#ifdef __CYGWIN__
+#pragma GCC diagnostic pop
+#endif
         ival = atoi(s);
         ival = htonl(ival);
         len = 4;


### PR DESCRIPTION
- Remove built-in dynamic peer discovery (Cygwin doesn't support certain libresolv calls)
- Make logging use Windows/DOS line endings
- Add a pragma to shut gcc up
- Add a note to the .conf file help to say on Windows internal DPD is not available
- Update INSTALL and README with some helpful comments
- This should resolve issue #157 for the most part