### PR TITLE
Cygwin fixes to fix #157

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -184,6 +184,12 @@ not `/usr/local'.  It is recommended to use the following options:
 
      ./configure --prefix=/boot/common
 
+   On Windows, use Cygwin for best results.  While this introduces 
+dependencies on several Cygwin DLLs, these are easily summarised by using
+the Dependency Walker utility.  We also recommend building radsecproxy 
+with an installation prefix other than `/usr/local' by giving
+`configure' the option `--prefix=PREFIX'.
+
 Specifying the System Type
 ==========================
 

--- a/README
+++ b/README
@@ -13,7 +13,7 @@ Fedora: dnf install radsecproxy
 FreeBSD: pkg install radsecproxy
 NetBSD: pkgin install radsecproxy
 
-Or built it from this source on most Unix like systems by simply typing
+Or build it from this source on most Unix like systems by simply typing
 
     ./configure && make
 
@@ -25,6 +25,10 @@ the location with the "-c" command line option (see below).  For further
 instructions, please see the enclosed example file and the manpages
 radsecproxy(8) and radsecproxy.conf(5).
 
-Note for Cygwin users:
-Due to a bug in openssl the tls option CACertificatePath is currently unusable.
-Use a certificate bundle with CACertificateFile instead.
+Notes for Cygwin users:
+- Due to a bug in openssl the tls option CACertificatePath is currently unusable.
+  Use a certificate bundle with CACertificateFile instead.
+- In newer versions of Cygwin, certain function calls to make internal dynamic peer 
+  discovery work are not available in libresolv (the linker complains). The internal 
+  dynamic peer discovery has been disabled and you're limited to static definitions 
+  or an external script.

--- a/debug.c
+++ b/debug.c
@@ -80,7 +80,11 @@ int debug_set_destination(char *dest, int log_type) {
 
     if (!strncasecmp(dest, "file:///", 8)) {
         if (log_type != LOG_TYPE_FTICKS) {
+#ifdef __CYGWIN__
+            debug_filepath = stringcopy(dest + 8, 0);
+#else
             debug_filepath = stringcopy(dest + 7, 0);
+#endif
             debug_file = fopen(debug_filepath, "a");
             if (!debug_file) {
                 debug_file = stderr;
@@ -200,10 +204,18 @@ void debug_logit(uint8_t level, const char *format, va_list ap) {
             /*ctime_r writes exactly 24 bytes + "\n\0" */
             strncpy(timebuf + 24, ": ", 3);
         }
+#ifdef __CYGWIN__
+        malloc_size = strlen(format) + (timebuf ? strlen(timebuf) : 0) + 4 * sizeof(char);
+#else
         malloc_size = strlen(format) + (timebuf ? strlen(timebuf) : 0) + 2 * sizeof(char);
+#endif
         tmp2 = malloc(malloc_size);
         if (tmp2) {
+#ifdef __CYGWIN__
+            snprintf(tmp2, malloc_size, "%s%s\r\n", timebuf ? timebuf : "", format);
+#else
             snprintf(tmp2, malloc_size, "%s%s\n", timebuf ? timebuf : "", format);
+#endif
             format = tmp2;
         }
         vfprintf(debug_file, format, ap);

--- a/radsecproxy.c
+++ b/radsecproxy.c
@@ -48,7 +48,9 @@
 #include <fcntl.h>
 #endif
 #include "debug.h"
+#ifndef __CYGWIN__
 #include "dns.h"
+#endif
 #include "dtls.h"
 #include "fticks.h"
 #include "fticks_hashmac.h"
@@ -2452,6 +2454,7 @@ int dynamicconfigexternal(struct server *server) {
     return ok;
 }
 
+#ifndef __CYGWIN__
 int dynamicconfigsrv(struct server *server, const char *srvstring) {
     struct clsrvconf *conf = server->conf;
     struct srv_record **srv;
@@ -2540,13 +2543,17 @@ int dynamicconfignaptr(struct server *server) {
     freenaptrresponse(naptr);
     return result;
 }
+#endif
 
 int dynamicconfig(struct server *server) {
+#ifndef __CYGWIN__
     struct clsrvconf *conf = server->conf;
     char *srvquery, *srvext;
+#endif
     int result = 0;
 
     debug(DBG_DBG, "dynamicconfig: need dynamic server config for %s", server->dynamiclookuparg);
+#ifndef __CYGWIN__
     if (strncasecmp(conf->dynamiclookupcommand, "naptr:", sizeof("naptr:") - 1) == 0) {
         result = dynamicconfignaptr(server);
     } else if (strncasecmp(conf->dynamiclookupcommand, "srv:", sizeof("srv:") - 1) == 0) {
@@ -2561,8 +2568,11 @@ int dynamicconfig(struct server *server) {
         result = dynamicconfigsrv(server, srvquery);
         free(srvquery);
     } else {
+#endif
         result = dynamicconfigexternal(server);
+#ifndef __CYGWIN__
     }
+#endif
 
     if (!result)
         debug(DBG_WARN, "dynamicconfig: failed to obtain dynamic server config for %s", server->dynamiclookuparg);

--- a/radsecproxy.conf-example
+++ b/radsecproxy.conf-example
@@ -23,7 +23,7 @@
 # Logging to file
 #LogDestination		file:///tmp/rp.log
 # On Windows, use the following format for a file destination instead:
-#LogDestination         file:///C:/this/directory/path/rp.log
+#LogDestination		file:///C:/this/directory/path/rp.log
 # Or logging with Syslog. LOG_DAEMON used if facility not specified
 # The supported facilities are LOG_DAEMON, LOG_MAIL, LOG_USER and
 # LOG_LOCAL0, ..., LOG_LOCAL7
@@ -92,6 +92,11 @@
 tls default {
     # You must specify at least one of CACertificateFile or CACertificatePath
     # for TLS to work. We always verify peer certificate (client and server)
+    # NOTES FOR WINDOWS USERS: 
+    # - CACertificatePath is currently unusable. Use a certificate bundle 
+    #   in CACertificateFile instead. 
+    # - Use a forward slash instead of a backslash as path separator, e.g.
+    #   C:/this/directory/path/file.ext
     # CACertificateFile    /etc/cacerts/CA.pem
     CACertificatePath	/etc/cacerts
 

--- a/radsecproxy.conf-example
+++ b/radsecproxy.conf-example
@@ -22,6 +22,8 @@
 # Optional LogDestination, else stderr used for logging
 # Logging to file
 #LogDestination		file:///tmp/rp.log
+# On Windows, use the following format for a file destination instead:
+#LogDestination         file:///C:/this/directory/path/rp.log
 # Or logging with Syslog. LOG_DAEMON used if facility not specified
 # The supported facilities are LOG_DAEMON, LOG_MAIL, LOG_USER and
 # LOG_LOCAL0, ..., LOG_LOCAL7

--- a/radsecproxy.conf.5.in
+++ b/radsecproxy.conf.5.in
@@ -641,6 +641,7 @@ Execute the \fIcommand\fR to dynamically configure a server for a realm given by
 the username field in an Access-Request. 
 The command can take two special forms, naptr:\fIservice\fR or srv:\fIprefix\fR,
 or point to a script or executable.
+NOTE: When built on Cygwin for Windows, only the script or executable is currently available.
 
 The \fBnaptr:\fR and \fBsrv:\fR forms execute the corresponding DNS queries, either searching 
 for \fIservice\fR in NAPTR records (followed by SRV query), or querying for 

--- a/rewrite.c
+++ b/rewrite.c
@@ -45,7 +45,14 @@ struct tlv *extractattr(char *nameval, char vendor_flag) {
     }
 
     s++;
+#ifdef __CYGWIN__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wchar-subscripts"
+#endif
     if (isdigit(*s)) {
+#ifdef __CYGWIN__
+#pragma GCC diagnostic pop
+#endif
         ival = atoi(s);
         ival = htonl(ival);
         len = 4;


### PR DESCRIPTION
These changes fix #157 by removing the dynamic peer discovery from the Windows build for the time being. 
This allows Windows users to use static definitions to speak RADIUS/TLS to their upstream RADIUS proxy.