### PR TITLE
Cygwin fixes to fix #157 

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -184,6 +184,15 @@ not `/usr/local'.  It is recommended to use the following options:
 
      ./configure --prefix=/boot/common
 
+   On Windows, use Cygwin for best results.  While this introduces 
+dependencies on several Cygwin DLLs, these are easily summarised by using
+the Dependency Walker utility.  We also recommend building radsecproxy 
+with an installation prefix other than `/usr/local' by giving
+`configure' the option `--prefix=PREFIX'.  For explicit DOS style
+line endings in radsecproxy output, use the following option:
+
+     ./configure LDFLAGS=/lib/textmode.o
+
 Specifying the System Type
 ==========================
 

--- a/README
+++ b/README
@@ -13,7 +13,7 @@ Fedora: dnf install radsecproxy
 FreeBSD: pkg install radsecproxy
 NetBSD: pkgin install radsecproxy
 
-Or built it from this source on most Unix like systems by simply typing
+Or build it from this source on most Unix like systems by simply typing
 
     ./configure && make
 
@@ -25,6 +25,39 @@ the location with the "-c" command line option (see below).  For further
 instructions, please see the enclosed example file and the manpages
 radsecproxy(8) and radsecproxy.conf(5).
 
-Note for Cygwin users:
-Due to a bug in openssl the tls option CACertificatePath is currently unusable.
-Use a certificate bundle with CACertificateFile instead.
+Notes for Cygwin users:
+- To build radsecproxy with explicit DOS style line endings in output, use
+  ./configure LDFLAGS=/lib/textmode.o
+- Due to a bug in openssl the tls option CACertificatePath is currently unusable.
+  Use a certificate bundle with CACertificateFile instead.
+- In newer versions of Cygwin, certain function calls to make internal dynamic peer 
+  discovery work are not available in libresolv (the linker complains). The internal 
+  dynamic peer discovery has been disabled and you're limited to static definitions 
+  or an external script.
+
+Notes for Windows users: 
+- To build radsecproxy, follow the Cygwin section above.
+- To use radsecproxy on Windows *without* dynamic peer discovery and without 
+  installing a complete copy of Cygwin:
+  - Build radsecproxy as per Cygwin above
+  - Add the following Cygwin DLL files alongside radsecproxy.exe and its config: 
+    - cygcrypto-3.dll, cygnettle-6.dll, cygssl-3.dll, cygwin1.dll, cygz.dll
+- To use radsecproxy *with* dynamic peer discovery (via external batch file) on 
+  Windows without a complete copy of Cygwin:
+  - Build radsecproxy as per Cygwin above
+  - Add the following Cygwin DLL files and executables alongside radsecproxy.exe 
+    and its config:
+    - cygcrypto-3.dll, cyggcc_s-seh-1.dll, cygiconv-2.dll, cygintl-8.dll, 
+      cygnettle-6.dll, cygpcre2-8-0.dll, cygssl-3.dll, cygwin1.dll, cygz.dll, 
+      echo.exe, grep.exe, printf.exe, sed.exe, sort.exe, tr.exe
+  - Download ISC BIND9 for Windows v9.16.48 from 
+    https://downloads.isc.org/isc/bind9/9.16.48/BIND9.16.48.x64.zip.
+    - Extract the ZIP file into the "bind" subdirectory of your radsecproxy directory.
+    - Do *NOT* use the installer. 
+  - Copy naptr-lookup.bat from the tools directory. (Un)comment the appropriate 
+    NAPTR_PATTERN line. The default is eduroam's NAPTR record.
+  - Test the batchfile by running it from the command-line with this command-line:
+    - c:\path\to\naptr-lookup.bat realm.ext (where realm.ext has a record you want)
+  - Resolve any path errors (missing executables, mostly)
+  - Make sure you set the complete path to naptr-lookup.bat surrounded by quotes, 
+    e.g. dynamicLookupCommand "c:/radsecproxy/naptr-openroaming.bat"

--- a/radsecproxy.c
+++ b/radsecproxy.c
@@ -48,7 +48,9 @@
 #include <fcntl.h>
 #endif
 #include "debug.h"
+#ifndef __CYGWIN__
 #include "dns.h"
+#endif
 #include "dtls.h"
 #include "fticks.h"
 #include "fticks_hashmac.h"
@@ -2455,6 +2457,7 @@ int dynamicconfigexternal(struct server *server) {
     return ok;
 }
 
+#ifndef __CYGWIN__
 int dynamicconfigsrv(struct server *server, const char *srvstring) {
     struct clsrvconf *conf = server->conf;
     struct srv_record **srv;
@@ -2543,13 +2546,17 @@ int dynamicconfignaptr(struct server *server) {
     freenaptrresponse(naptr);
     return result;
 }
+#endif
 
 int dynamicconfig(struct server *server) {
+#ifndef __CYGWIN__
     struct clsrvconf *conf = server->conf;
     char *srvquery, *srvext;
+#endif
     int result = 0;
 
     debug(DBG_DBG, "dynamicconfig: need dynamic server config for %s", server->dynamiclookuparg);
+#ifndef __CYGWIN__
     if (strncasecmp(conf->dynamiclookupcommand, "naptr:", sizeof("naptr:") - 1) == 0) {
         result = dynamicconfignaptr(server);
     } else if (strncasecmp(conf->dynamiclookupcommand, "srv:", sizeof("srv:") - 1) == 0) {
@@ -2564,8 +2571,11 @@ int dynamicconfig(struct server *server) {
         result = dynamicconfigsrv(server, srvquery);
         free(srvquery);
     } else {
+#endif
         result = dynamicconfigexternal(server);
+#ifndef __CYGWIN__
     }
+#endif
 
     if (!result)
         debug(DBG_WARN, "dynamicconfig: failed to obtain dynamic server config for %s", server->dynamiclookuparg);

--- a/radsecproxy.conf-example
+++ b/radsecproxy.conf-example
@@ -22,6 +22,8 @@
 # Optional LogDestination, else stderr used for logging
 # Logging to file
 #LogDestination		file:///tmp/rp.log
+# On Windows, use the following format for a file destination instead:
+#LogDestination		file:///C:/this/directory/path/rp.log
 # Or logging with Syslog. LOG_DAEMON used if facility not specified
 # The supported facilities are LOG_DAEMON, LOG_MAIL, LOG_USER and
 # LOG_LOCAL0, ..., LOG_LOCAL7
@@ -90,6 +92,11 @@
 tls default {
     # You must specify at least one of CACertificateFile or CACertificatePath
     # for TLS to work. We always verify peer certificate (client and server)
+    # NOTES FOR WINDOWS USERS: 
+    # - CACertificatePath is currently unusable. Use a certificate bundle 
+    #   in CACertificateFile instead. 
+    # - Use a forward slash instead of a backslash as path separator, e.g.
+    #   C:/this/directory/path/file.ext
     # CACertificateFile    /etc/cacerts/CA.pem
     CACertificatePath	/etc/cacerts
 
@@ -233,6 +240,10 @@ server dyndisc {
 	dynamicLookupCommand naptr:x-eduroam:radius.tls
 	#alternatively call a script that poerforms the lookup
 	#dynamicLookupCommand /usr/local/bin/naptr-eduroam.sh
+	# NOTES FOR WINDOWS (Cygwin) USERS:
+	# For dynamic lookups on Windows, see READNE for instructions
+	# Use the full path to the batch file below
+	#dynamicLookupCommand "c:/full/path/to/batchfile/naptr-lookup.bat"
 }
 
 # Equivalent to example.com

--- a/radsecproxy.conf-example
+++ b/radsecproxy.conf-example
@@ -21,14 +21,14 @@
 #LogLevel		3
 # Optional LogDestination, else stderr used for logging
 # Logging to file
-#LogDestination		file:///tmp/rp.log
+#LogDestination		file:/tmp/rp.log
 # On Windows, use the following format for a file destination instead:
-#LogDestination		file:///C:/this/directory/path/rp.log
+#LogDestination		file:C:/this/directory/path/rp.log
 # Or logging with Syslog. LOG_DAEMON used if facility not specified
 # The supported facilities are LOG_DAEMON, LOG_MAIL, LOG_USER and
 # LOG_LOCAL0, ..., LOG_LOCAL7
 #LogDestination         x-syslog:///
-#LogDestination         x-syslog:///log_local2
+#LogDestination         x-syslog:log_local2
 # Optional log thread Id
 #LogThreadId on
 
@@ -66,9 +66,9 @@
 # syslog facility for F-Ticks messages. This allows for easier filtering
 # of F-Ticks messages.
 # F-Ticks messages are always logged using the log level LOG_DEBUG.
-# Note that specifying a file (using the file:/// prefix) is not supported.
+# Note that specifying a file (using the file: prefix) is not supported.
 #FTicksSyslogFacility	log_local1
-#FTicksSyslogFacility	x-syslog:///log_local1
+#FTicksSyslogFacility	x-syslog:log_local1
 # If you are using radsecproxy outside the eduroam context, and you want
 # F-Ticks messages to have your own prefix instead of eduroam, you can set:
 #FTicksPrefix <prefix>

--- a/radsecproxy.conf.5.in
+++ b/radsecproxy.conf.5.in
@@ -649,6 +649,7 @@ Execute the \fIcommand\fR to dynamically configure a server for a realm given by
 the username field in an Access-Request. 
 The command can take two special forms, naptr:\fIservice\fR or srv:\fIprefix\fR,
 or point to a script or executable.
+NOTE: When built on Cygwin for Windows, only the script or executable is currently available.
 
 The \fBnaptr:\fR and \fBsrv:\fR forms execute the corresponding DNS queries, either searching 
 for \fIservice\fR in NAPTR records (followed by SRV query), or querying for 

--- a/tools/naptr-lookup.bat
+++ b/tools/naptr-lookup.bat
@@ -1,0 +1,143 @@
+@ECHO OFF
+REM This script looks up radsec srv records in DNS for the one
+REM realm given as argument, and creates a server template based
+REM on that. It currently ignores weight markers, but does sort
+REM servers on priority marker, lowest number first.
+REM For host command this is column 5, for dig it is column 1.
+REM 
+REM We key *everything* off the directory that this batchfile runs from:
+cd %~dp0
+
+REM We use delayed expansion in the loops, those variables use !var!, not %var%
+SETLOCAL ENABLEDELAYEDEXPANSION
+
+REM Uncomment the appropriate line for eduroam or OpenRoaming
+REM eduroam
+set NAPTR_PATTERN=x-eduroam:radius.tls
+REM OpenRoaming
+REM set NAPTR_PATTERN=aaa+auth:radius.tls.tcp
+
+REM 
+REM There is nothing else to edit from here!!
+REM
+if "x%~1"=="x" goto :usage
+goto :start_validate
+
+:usage
+  echo Usage: %~0 ^<realm^>
+  exit 1
+
+:start_validate
+REM our utilities - dig and host come from BIND9
+set digcmd="%~dp0\bind\dig.exe"
+set hostcmd="%~dp0\bind\host.exe"
+REM our utilities - these all come from cygwin
+set printcmd="%~dp0\printf.exe"
+set echocmd="%~dp0\echo.exe"
+set grepcmd="%~dp0\grep.exe"
+set sedcmd="%~dp0\sed.exe"
+set sortcmd="%~dp0\sort.exe"
+set trcmd="%~dp0\tr.exe"
+
+REM Here we go, validate the realm
+call :FUNC_validate_host %1 ORIG_REALM
+
+REM Check the whether the realm validated ok
+if "%ORIG_REALM%x"=="x" (
+  echo Error: realm "%1" failed validation
+  goto :usage
+)
+
+REM Validate if the realm is a 3GPP one, if so, munge it for some of the functions
+call :FUNC_validate_3gppnetwork %ORIG_REALM% REALM
+
+REM Check the whether the realm validated ok
+if "%REALM%x"=="x" (
+  echo Error: realm "%1" failed validation
+  goto :usage
+)
+
+REM
+REM Now let's get on with the real thing.
+REM
+
+REM DIG for the NAPTR record
+call :FUNC_dig_it_naptr %REALM%
+IF NOT "x%SERVERS%" == "x" ( 
+     %printcmd% "server dynamic_radsec.%ORIG_REALM% {\n%SERVERS%\n\ttype TLS\n}\n"
+     exit 0
+)
+
+REM Go to the end of the batch file
+goto :end
+
+REM Beyond this point we only have functions (or subs, as Windows calls them)
+
+:FUNC_validate_host
+for /f "delims=" %%r in ('^"%echocmd% %1 ^|^"%trcmd% -d ^' \042\n\t\r\^'^'') do set validate_host_realm=%%r
+for /f "delims=" %%r in ('^"%echocmd% %validate_host_realm% ^|^"%grepcmd% -E ^'^[_0-9a-zA-Z][-._0-9a-zA-Z]*$^'') do set validate_host_realm=%%r
+for /f "delims=" %%r in ('^"%echocmd% %validate_host_realm% ^|^"%trcmd% ^'[:upper:]^' ^'[:lower:]^'') do set validate_host_realm=%%r
+set %2=%validate_host_realm%
+exit /b
+
+
+:FUNC_validate_3gppnetwork
+for /f "delims=" %%r in ('^"%echocmd% %1 ^|^"%grepcmd% ^'\.pub\.3gppnetwork\.org$^'') do set test3gpppub=%%r
+for /f "delims=" %%r in ('^"%echocmd% %1 ^|^"%grepcmd% ^'\.3gppnetwork\.org$^'') do set test3gpp=%%r
+if NOT "x%test3gpppub%" == "x" (
+  set validate_3gppnetwork_realm=%1
+) else ( 
+  if "x%test3gpp%" == "x" (
+    set validate_3gppnetwork_realm=%1
+  ) else (
+    for /f "delims=" %%r in ('^"%echocmd% %1 ^|^"%sedcmd% -E ^'s/^^^(.*^)^(\.3gppnetwork\.org^)$/\1\.pub\2/g^'') do set validate_3gppnetwork_realm=%%r
+  )
+)
+set %2=%validate_3gppnetwork_realm%
+exit /b
+
+
+:FUNC_validate_port
+for /f "delims=" %%r in ('^"%echocmd% %1 ^|^"%trcmd% -d ^'\s\042\n\t\r\^'^'') do set validate_port=%%r
+for /f "delims=" %%r in ('^"%echocmd% %validate_port% ^|^"%grepcmd% -E ^'^[0-9]+$^'') do set validate_port=%%r
+set %2=%validate_port%
+exit /b
+
+
+:FUNC_dig_it_srv
+for /f "delims=" %%k in ('^"%digcmd% +short srv %1 ^|%sortcmd%^" -n -k1 ') do (
+  set line=%%k
+  for /f "tokens=3,4 delims= " %%l in ("!line!") do (
+    call :FUNC_validate_port %%l line_srv_port
+    call :FUNC_validate_host %%m line_srv_host
+    for /f "delims=" %%z in ('^"%echocmd% !line_srv_host! ^|%sedcmd%^" -E ^'s/^(.*^)\.$/\1/g^'') do set line_srv_host=%%z
+  )
+  IF NOT "x!line_srv_host!" == "x" (
+     IF "x!line_srv_port!" == "x" set line_srv_port=2083
+     set srv_host_line=\thost !line_srv_host!:!line_srv_port!\n
+  )
+  IF "x!host_line!" == "x" ( set host_line=!srv_host_line! ) else ( set host_line=!host_line!!srv_host_line! )
+)
+set %2=%host_line%
+exit /b
+
+
+:FUNC_dig_it_naptr
+for /f "delims=" %%r in ('^"%digcmd% +short naptr %1 ^|%grepcmd% %NAPTR_PATTERN% ^|%sortcmd%^" -n -k1 ') do (
+  set line=%%r
+  for /f "tokens=3,6 delims= " %%t in ("!line!") do (
+    IF x%%t == x"s" set line_srv_token=%%u
+    IF x%%t == x"S" set line_srv_token=%%u
+  )
+  call :FUNC_validate_host !line_srv_token! SRV_HOST
+  IF NOT "x!SRV_HOST!" == "x" (
+    call :FUNC_dig_it_srv !SRV_HOST! srv_host_line
+    IF "x!SERVERS!" == "x" ( set SERVERS=!srv_host_line! ) else ( set SERVERS=!SERVERS!!srv_host_line! )
+  )
+)
+exit /b
+
+
+REM No server found.
+:end
+exit 10


### PR DESCRIPTION
These changes fix https://github.com/radsecproxy/radsecproxy/issues/157 and https://github.com/radsecproxy/radsecproxy/issues/162 by working around built-in dynamic peer discovery in the Windows build for the time being.

This allows Windows users to use static definitions to speak RADIUS/TLS to their upstream RADIUS proxy, or use a combination of ISC BIND9 for Windows and additional Cygwin utilities to do dynamic peer discovery on Windows.

Successor to https://github.com/radsecproxy/radsecproxy/pull/161 and https://github.com/radsecproxy/radsecproxy/pull/162 