### PR TITLE
Dtls version fix master

### DIFF
--- a/tlscommon.c
+++ b/tlscommon.c
@@ -1173,7 +1173,7 @@ static int conf_tls_version(uint8_t dtls, const char *version, int *min, int *ma
     *min = parse_tls_version(dtls, smin);
     *max = parse_tls_version(dtls, smax);
     free(ver);
-    return *min >= 0 && *max >= 0 && (*max == 0 || *min <= *max);
+    return *min >= 0 && *max >= 0 && (*max == 0 || (!dtls && *min <= *max) || (dtls && *min >= *max));
 }
 #endif
 


### PR DESCRIPTION
When specifying `DtlsVersion DTLS1:DTLS1_2` in a tls block. there is an error "invalid DtlsVersion DTLS1:DTLS1_2".

TLS versions values are defined in ascending order in Openssl but DTLS versions values are defined in descending order. Therefore, in the mentioned case, `conf_tls_version()` returns false (last comparison):