### PR TITLE
Fix uninitialized value in tls.c / dtls.c

### DIFF
--- a/dtls.c
+++ b/dtls.c
@@ -106,7 +106,7 @@ void *dtlsservernew(void *arg) {
     struct timeval timeout;
     struct addrinfo tmpsrvaddr;
     char tmp[INET6_ADDRSTRLEN], *subj;
-    struct hostportres *hp;
+    struct hostportres *hp = NULL;
 
     debug(DBG_WARN, "dtlsservernew: incoming DTLS connection from %s", addr2string((struct sockaddr *)&params->addr, tmp, sizeof(tmp)));
 

--- a/tls.c
+++ b/tls.c
@@ -341,7 +341,7 @@ void *tlsservernew(void *arg) {
     struct client *client;
     struct tls *accepted_tls = NULL;
     char tmp[INET6_ADDRSTRLEN], *subj;
-    struct hostportres *hp;
+    struct hostportres *hp = NULL;
 
     s = *(int *)arg;
     free(arg);


### PR DESCRIPTION
This PR fixes an uninitialized value in `tls.c` and `dtls.c`

In `hostport.c` the value is used in this statement:
`if (hpreturn && *hpreturn)`
If called from `tlsservernew` or `dtlsservernew`, the value that ends up in `hpreturn` through the call chain is uninitialized.

Output from valgrid (as example for tls)

```
<date>: tlsservernew: incoming TLS connection from <ipaddr>
==922433== Thread 26:
==922433== Conditional jump or move depends on uninitialised value(s)
==922433==    at 0x128B6A: _internal_addressmatches (hostport.c:297)
==922433==    by 0x1105AB: find_conf (radsecproxy.c:123)
==922433==    by 0x11BE1D: tlsservernew (tls.c:354)
==922433==    by 0x4E271F4: start_thread (pthread_create.c:442)
==922433==    by 0x4EA6B3F: clone (clone.S:100)
==922433==
```