### PR TITLE
Replace sprintf/strcpy/strcat/strncpy with bounded equivalents

### DIFF
--- a/debug.c
+++ b/debug.c
@@ -156,7 +156,7 @@ void debug_logit(uint8_t level, const char *format, va_list ap) {
 #ifdef __linux__
         pid_t tid = syscall(SYS_gettid);
         tidbuf = malloc(3 * sizeof(tid) + 1);
-        sprintf(tidbuf, "%u", tid);
+        snprintf(tidbuf, 3 * sizeof(tid) + 1, "%u", tid);
 #else
         pthread_t tid = pthread_self();
         uint8_t *ptid = (uint8_t *)&tid;
@@ -165,11 +165,11 @@ void debug_logit(uint8_t level, const char *format, va_list ap) {
         tidbuf = malloc((2 * sizeof(tid) + 1));
         tmp = tidbuf;
         for (i = sizeof(tid) - 1; i >= 0; i--) {
-            tmp += sprintf(tmp, "%02x", ptid[i]);
+            tmp += snprintf(tmp, 3, "%02x", ptid[i]);
         }
 #endif
         tmp = malloc(strlen(tidbuf) + strlen(format) + 4);
-        sprintf(tmp, "(%s) %s", tidbuf, format);
+        snprintf(tmp, strlen(tidbuf) + strlen(format) + 4, "(%s) %s", tidbuf, format);
         format = tmp;
         free(tidbuf);
     }
@@ -268,7 +268,7 @@ void debugerrno(int err, uint8_t level, char *format, ...) {
         size_t len = strlen(format);
         char *tmp = malloc(len + 1024 + 2);
         assert(tmp);
-        strcpy(tmp, format);
+        strlcpy(tmp, format, len + 1);
         tmp[len++] = ':';
         tmp[len++] = ' ';
         va_start(ap, format);

--- a/fticks_hashmac.c
+++ b/fticks_hashmac.c
@@ -22,7 +22,7 @@ static void _format_hash(const uint8_t *hash, size_t out_len, uint8_t *out) {
     }
 
     for (ir = 0, iw = 0; iw <= out_len - 3; ir++, iw += 2)
-        sprintf((char *)out + iw, "%02x", hash[ir % EVP_MD_size(sha256digest())]);
+        snprintf((char *)out + iw, out_len - iw, "%02x", hash[ir % EVP_MD_size(sha256digest())]);
 }
 
 static void _hash(const uint8_t *in,

--- a/gconfig.c
+++ b/gconfig.c
@@ -133,14 +133,15 @@ FILE *pushgconfpaths(struct gconffile **cf, const char *cfgpath) {
             goto exit;
         }
         dir = dirname(curfile);
-        path = malloc(strlen(dir) + strlen(cfgpath) + 2);
+        size_t dlen = strlen(dir), plen = strlen(cfgpath);
+        path = malloc(dlen + plen + 2);
         if (!path) {
             debug(DBG_ERR, "malloc failed");
             goto exit;
         }
-        strcpy(path, dir);
-        path[strlen(dir)] = '/';
-        strcpy(path + strlen(dir) + 1, cfgpath);
+        strlcpy(path, dir, dlen + 1);
+        path[dlen] = '/';
+        strlcpy(path + dlen + 1, cfgpath, plen + 1);
     }
     memset(&globbuf, 0, sizeof(glob_t));
     if (glob(path, 0, NULL, &globbuf)) {
@@ -539,12 +540,14 @@ int getgenericconfig(struct gconffile **cf, char *block, ...) {
             }
             break;
         case CONF_CBK:
-            optval = malloc(strlen(opt) + strlen(val) + 2);
+            ;
+            size_t optval_sz = strlen(opt) + strlen(val) + 2;
+            optval = malloc(optval_sz);
             if (!optval) {
                 debug(DBG_ERR, "malloc failed");
                 goto errexit;
             }
-            sprintf(optval, "%s %s", opt, val);
+            snprintf(optval, optval_sz, "%s %s", opt, val);
             if (!cbk(cf, cbkarg, optval, opt, val)) {
                 free(optval);
                 goto errexit;

--- a/hostport.c
+++ b/hostport.c
@@ -172,6 +172,7 @@ int resolvehostport(struct hostportres *hp, int af, int socktype, uint8_t passiv
             numaddr++;
     }
     if (numaddr) {
+        size_t bufsize = numaddr * (INET6_ADDRSTRLEN + 2);
         if (!(buf = calloc(numaddr, INET6_ADDRSTRLEN + 2))) {
             debug(DBG_ERR, "resolvehostport: calloc failed");
             return 1;
@@ -179,9 +180,9 @@ int resolvehostport(struct hostportres *hp, int af, int socktype, uint8_t passiv
         for (res = hp->addrinfo; res; res = res->ai_next) {
             if (!res->ai_addr)
                 continue;
-            strcat(buf, addr2string(res->ai_addr, tmp, sizeof(tmp)));
+            strlcat(buf, addr2string(res->ai_addr, tmp, sizeof(tmp)), bufsize);
             if (res->ai_next)
-                strcat(buf, ", ");
+                strlcat(buf, ", ", bufsize);
         }
     }
     debug(DBG_DBG, "%s: %s -> %s", __func__,

--- a/radsecproxy.c
+++ b/radsecproxy.c
@@ -1091,7 +1091,7 @@ void replylog(struct radmsg *msg, struct server *server, struct request *rq) {
     }
     stationid = radattr2ascii(radmsg_gettype(rq->msg, RAD_Attr_Calling_Station_Id));
     if (stationid) {
-        sprintf((char *)logstationid, " stationid ");
+        snprintf((char *)logstationid, sizeof(logstationid), " stationid ");
         switch (options.log_mac) {
         case RSP_MAC_VENDOR_HASHED:
         case RSP_MAC_VENDOR_KEY_HASHED:
@@ -1103,11 +1103,11 @@ void replylog(struct radmsg *msg, struct server *server, struct request *rq) {
             fticks_hashmac((uint8_t *)stationid, options.log_mac == RSP_MAC_FULLY_KEY_HASHED ? options.log_key : NULL, 65, (uint8_t *)logstationid + 11);
             break;
         case RSP_MAC_STATIC:
-            sprintf(logstationid + 11, "undisclosed");
+            snprintf(logstationid + 11, sizeof(logstationid) - 11, "undisclosed");
             break;
         case RSP_MAC_ORIGINAL:
         default:
-            strncpy(logstationid + 11, (char *)stationid, 128 - 12);
+            strlcpy(logstationid + 11, (char *)stationid, sizeof(logstationid) - 11);
         }
         free(stationid);
     }
@@ -2528,21 +2528,23 @@ int dynamicconfigsrv(struct server *server, const char *srvstring) {
     }
 
     for (i = 0; srv[i]; i++) {
-        char *hostport = malloc(strlen(srv[i]->host) + sizeof(":65535"));
+        size_t hostport_sz = strlen(srv[i]->host) + sizeof(":65535");
+        char *hostport = malloc(hostport_sz);
         if (!hostport) {
             debug(DBG_ERR, "malloc failed");
             goto exithostport;
         }
-        sprintf(hostport, "%s:%d", srv[i]->host, srv[i]->port);
+        snprintf(hostport, hostport_sz, "%s:%d", srv[i]->host, srv[i]->port);
         hostports[i] = hostport;
     }
 
-    servername = malloc(strlen("dynamic:") + strlen(server->dynamiclookuparg) + 1);
+    size_t servername_sz = strlen("dynamic:") + strlen(server->dynamiclookuparg) + 1;
+    servername = malloc(servername_sz);
     if (!servername) {
         debug(DBG_ERR, "malloc failed");
         goto exithostport;
     }
-    sprintf(servername, "dynamic:%s", server->dynamiclookuparg);
+    snprintf(servername, servername_sz, "dynamic:%s", server->dynamiclookuparg);
 
     conf->name = servername;
     conf->hostsrc = hostports;
@@ -2598,10 +2600,11 @@ int dynamicconfig(struct server *server) {
         srvext = strchr(conf->dynamiclookupcommand, ':');
         if (!srvext)
             return 0;
-        srvquery = malloc((strlen(srvext) + 1 + strlen(server->dynamiclookuparg) + 1) * sizeof(char));
+        size_t srvquery_sz = strlen(srvext) + 1 + strlen(server->dynamiclookuparg) + 1;
+        srvquery = malloc(srvquery_sz);
         if (!srvquery)
             return 0;
-        sprintf(srvquery, "%s%s%s", srvext + 1, conf->dynamiclookupcommand[strlen(conf->dynamiclookupcommand) - 1] == '.' ? "" : ".", server->dynamiclookuparg);
+        snprintf(srvquery, srvquery_sz, "%s%s%s", srvext + 1, conf->dynamiclookupcommand[strlen(conf->dynamiclookupcommand) - 1] == '.' ? "" : ".", server->dynamiclookuparg);
 
         result = dynamicconfigsrv(server, srvquery);
         free(srvquery);


### PR DESCRIPTION
Replace sprintf→snprintf, strcat→strlcat, strcpy/strncpy→strlcpy across debug.c, fticks_hashmac.c, gconfig.c, hostport.c, and radsecproxy.c. Introduces local size variables where needed so buffer bounds are explicit at every call site.