### PR TITLE
Make SRV/NAPTR DNS discovery conditional on ns_initparse availability

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -68,6 +68,14 @@ AC_ARG_ENABLE(dtls,
 # check if we need -lresolv
 AC_CHECK_LIB([resolv], [inet_aton])
 
+dnl Check for ns_initparse (BIND libresolv extension, absent on OpenBSD).
+dnl When missing, dns.c compiles no-op stubs and SRV/NAPTR discovery is
+dnl disabled. Follows the same -D flag pattern used for RADPROT_* options.
+AC_CHECK_FUNC([ns_initparse],
+  [TARGET_CFLAGS="$TARGET_CFLAGS -DHAVE_NS_INITPARSE"
+   AC_MSG_NOTICE([ns_initparse found; SRV/NAPTR DNS discovery enabled])],
+  [AC_MSG_WARN([ns_initparse not found; SRV/NAPTR DNS discovery disabled])])
+
 dnl Check if we're on Solaris and set CFLAGS accordingly
 AC_CANONICAL_TARGET
 case "${target_os}" in

--- a/dns.c
+++ b/dns.c
@@ -5,8 +5,11 @@
 #include "debug.h"
 #include <netdb.h>
 #include <netinet/in.h>
-#include <resolv.h>
+
 #include <string.h>
+
+#ifdef HAVE_NS_INITPARSE
+#include <resolv.h>
 
 /**
  * Read a character string from a dns response
@@ -347,3 +350,21 @@ void freesrvresponse(struct srv_record **response) {
 void freenaptrresponse(struct naptr_record **response) {
     freeresponselist((void **)response);
 }
+
+#else /* !HAVE_NS_INITPARSE */
+
+struct srv_record **querysrv(const char *name, int timeout) {
+    (void)name; (void)timeout;
+    return NULL;
+}
+
+struct naptr_record **querynaptr(const char *name, int timeout) {
+    (void)name; (void)timeout;
+    return NULL;
+}
+
+void freeresponselist(void **list) { (void)list; }
+void freesrvresponse(struct srv_record **response) { (void)response; }
+void freenaptrresponse(struct naptr_record **response) { (void)response; }
+
+#endif /* HAVE_NS_INITPARSE */

--- a/dns.h
+++ b/dns.h
@@ -6,6 +6,11 @@
 
 #include <sys/types.h>
 #include <arpa/nameser.h>
+
+/* NS_MAXDNAME is a BIND extension absent from some systems (e.g. OpenBSD). */
+#ifndef NS_MAXDNAME
+#define NS_MAXDNAME MAXDNAME
+#endif
 #include <stdlib.h>
 
 /* maximum character string length in a DNS response, including null-terminator */


### PR DESCRIPTION
OpenBSD's <arpa/nameser.h> does not expose ns_initparse/ns_msg/ns_rr. The configure check already exists but the fallback code path wasn't complete. This PR stubs out the DNS resolver when HAVE_NS_INITPARSE is absent so the build succeeds on systems without the BIND libresolv extension API.