### PR TITLE
add dynamic meta-attribute rewrite

### DIFF
--- a/radsecproxy.c
+++ b/radsecproxy.c
@@ -1490,8 +1490,11 @@ int radsrv(struct request *rq) {
         goto exit;
     }
 
-    if (from->conf->rewritein && !dorewrite(msg, from->conf->rewritein))
-        goto rmclrqexit;
+    {
+        struct rewrite_context ctx = {from->addr, from->conf->name};
+        if (from->conf->rewritein && !dorewrite(msg, from->conf->rewritein, &ctx))
+            goto rmclrqexit;
+    }
 
     ttlres = checkttl(msg, options.ttlattrtype);
     if (!ttlres) {
@@ -1584,8 +1587,11 @@ int radsrv(struct request *rq) {
             goto rmclrqexit;
     }
 
-    if (to->conf->rewriteout && !dorewrite(msg, to->conf->rewriteout))
-        goto rmclrqexit;
+    {
+        struct rewrite_context ctx = {from->addr, from->conf->name};
+        if (to->conf->rewriteout && !dorewrite(msg, to->conf->rewriteout, &ctx))
+            goto rmclrqexit;
+    }
 
     if (msg->code == RAD_Access_Request &&
         !ensuremsgauthfront(msg))
@@ -1754,9 +1760,12 @@ int replyh(struct server *server, uint8_t *buf, int len) {
 
     gettimeofday(&server->lastreply, NULL);
 
-    if (server->conf->rewritein && !dorewrite(msg, server->conf->rewritein)) {
-        debug(DBG_INFO, "replyh: rewritein failed");
-        goto errunlock;
+    {
+        struct rewrite_context ctx = {rqout->rq->from->addr, rqout->rq->from->conf->name};
+        if (server->conf->rewritein && !dorewrite(msg, server->conf->rewritein, &ctx)) {
+            debug(DBG_INFO, "replyh: rewritein failed");
+            goto errunlock;
+        }
     }
 
     ttlres = checkttl(msg, options.ttlattrtype);
@@ -1822,9 +1831,12 @@ int replyh(struct server *server, uint8_t *buf, int len) {
         memcpy(attr->v, rqout->rq->origusername, strlen(rqout->rq->origusername));
     }
 
-    if (from->conf->rewriteout && !dorewrite(msg, from->conf->rewriteout)) {
-        debug(DBG_WARN, "replyh: rewriteout failed");
-        goto errunlock;
+    {
+        struct rewrite_context ctx = {from->addr, from->conf->name};
+        if (from->conf->rewriteout && !dorewrite(msg, from->conf->rewriteout, &ctx)) {
+            debug(DBG_WARN, "replyh: rewriteout failed");
+            goto errunlock;
+        }
     }
 
     if ((msg->code == RAD_Access_Challenge || msg->code == RAD_Access_Accept || msg->code == RAD_Access_Reject) &&
@@ -3297,6 +3309,8 @@ int confrewrite_cb(struct gconffile **cf, void *arg, char *block, char *opt, cha
     char **addattrs = NULL, **addvattrs = NULL;
     char **modattrs = NULL, **modvattrs = NULL;
     char **supattrs = NULL, **supvattrs = NULL;
+    char **addmetaattrs = NULL, **addmetavattrs = NULL;
+    char **supmetaattrs = NULL, **supmetavattrs = NULL;
 
     debug(DBG_DBG, "confrewrite_cb called for %s", block);
 
@@ -3312,10 +3326,15 @@ int confrewrite_cb(struct gconffile **cf, void *arg, char *block, char *opt, cha
                           "modifyVendorAttribute", CONF_MSTR, &modvattrs,
                           "supplementAttribute", CONF_MSTR_NOESC, &supattrs,
                           "supplementVendorAttribute", CONF_MSTR_NOESC, &supvattrs,
+                          "addMetaAttribute", CONF_MSTR, &addmetaattrs,
+                          "addMetaVendorAttribute", CONF_MSTR, &addmetavattrs,
+                          "supplementMetaAttribute", CONF_MSTR, &supmetaattrs,
+                          "supplementMetaVendorAttribute", CONF_MSTR, &supmetavattrs,
                           NULL))
         debugx(1, DBG_ERR, "configuration error");
     addrewrite(val, whitelist_mode, whitelist_mode ? wlattrs : rmattrs, whitelist_mode ? wlvattrs : rmvattrs,
-               addattrs, addvattrs, modattrs, modvattrs, supattrs, supvattrs);
+               addattrs, addvattrs, modattrs, modvattrs, supattrs, supvattrs,
+               addmetaattrs, addmetavattrs, supmetaattrs, supmetavattrs);
 
     freegconfmstr(whitelist_mode ? rmattrs : wlattrs);
     freegconfmstr(whitelist_mode ? rmvattrs : wlvattrs);

--- a/radsecproxy.conf-example
+++ b/radsecproxy.conf-example
@@ -142,6 +142,15 @@ tls default {
 #	modifyAttribute 1:/^(.*)@local$/\1@example.com/
 # }
 
+# Inject the client's source IP as a vendor-specific attribute.
+# Useful when proxying to preserve the original client IP address.
+# rewrite injectSourceIP {
+#       # Add source IP as vendor attribute (vendor 12345, sub-type 1)
+#       addMetaVendorAttribute 12345:1:source_ip
+#       # Or add source IP as Calling-Station-Id only if not already present
+#       # supplementMetaAttribute 31:source_ip
+# }
+
 client [2001:db8::1] {
 	type	tls
 	secret	verysecret

--- a/radsecproxy.conf.5.in
+++ b/radsecproxy.conf.5.in
@@ -1075,7 +1075,11 @@ The rewrite actions are performed in this sequence:
 .br
 3. SupplementAttribute
 .br
-4. AddAttribute
+4. SupplementMetaAttribute
+.br
+5. AddAttribute
+.br
+6. AddMetaAttribute
 .RE
 
 All options can be specified multiple times. The allowed options in a rewrite
@@ -1111,6 +1115,44 @@ the same as for \fBaddAttribute\fR above.
 Add a vendor attribute to the radius message only if the \fIsubattribute\fR of
 this \fIvendor\fR is not yet present on the message. The format of is the same
 as for \fBaddVendorAttribute\fR above.
+.RE
+
+.BI "AddMetaAttribute " attribute \fR: keyword
+.RS
+Add an \fIattribute\fR to the radius message with a value resolved at runtime
+from connection metadata. The \fIattribute\fR must be specified using the
+numerical attribute id. The \fIkeyword\fR identifies which metadata to use.
+The metadata always refers to the originating client of the request, even
+when the rewrite is applied on a response path (i.e., \fBsource_ip\fR is
+the IP of the client that sent the original request, not the upstream
+server's IP).
+Supported keywords are:
+.br
+\fBsource_ip\fR \- the source IP address of the client connection (string)
+.br
+\fBsource_port\fR \- the source port of the client connection (string)
+.br
+\fBclient_name\fR \- the name of the client configuration block (string)
+.RE
+
+.BI "AddMetaVendorAttribute " vendor \fR: subattribute \fR: keyword
+.RS
+Add a vendor attribute to the radius message with a value resolved at runtime
+from connection metadata. Both \fIvendor\fR and \fIsubattribute\fR must be
+specified as numerical values. The \fIkeyword\fR is the same as for
+\fBAddMetaAttribute\fR above.
+.RE
+
+.BI "SupplementMetaAttribute " attribute \fR: keyword
+.RS
+Like \fBAddMetaAttribute\fR, but only adds the attribute if it is not already
+present on the message.
+.RE
+
+.BI "SupplementMetaVendorAttribute " vendor \fR: subattribute \fR: keyword
+.RS
+Like \fBAddMetaVendorAttribute\fR, but only adds the vendor attribute if the
+\fIsubattribute\fR of this \fIvendor\fR is not already present on the message.
 .RE
 
 .BI "ModifyAttribute " attribute \fR:/ regex \fR/ replace \fR/

--- a/rewrite.c
+++ b/rewrite.c
@@ -155,15 +155,119 @@ struct modattr *extractmodvattr(char *nameval) {
     return modvattr;
 }
 
+static int validmetafield(const char *field) {
+    return strcmp(field, "source_ip") == 0 ||
+           strcmp(field, "source_port") == 0 ||
+           strcmp(field, "client_name") == 0;
+}
+
+struct dynattr *extractdynattr(char *nameval, char vendor_flag) {
+    int name = 0;
+    long vendor = 0;
+    char *s, *s2;
+    struct dynattr *da;
+
+    s = strchr(nameval, ':');
+    if (!s)
+        return NULL;
+    name = atoi(nameval);
+
+    if (vendor_flag) {
+        s2 = strchr(s + 1, ':');
+        if (!s2)
+            return NULL;
+        vendor = name;
+        name = atoi(s + 1);
+        s = s2;
+    }
+
+    s++;
+    if (name < 1 || name > 255)
+        return NULL;
+    /* RADIUS vendor PEN is 24-bit per RFC 2865 */
+    if (vendor_flag && (vendor < 1 || vendor > 0xFFFFFF))
+        return NULL;
+    if (!validmetafield(s))
+        return NULL;
+
+    da = malloc(sizeof(struct dynattr));
+    if (!da)
+        return NULL;
+    da->t = name;
+    da->vendor = vendor;
+    da->field = stringcopy(s, 0);
+    if (!da->field) {
+        free(da);
+        return NULL;
+    }
+    return da;
+}
+
+static struct tlv *resolvedynattr(struct dynattr *da, struct rewrite_context *ctx) {
+    char buf[INET6_ADDRSTRLEN];
+    char portbuf[6];
+    const char *val = NULL;
+    struct tlv *a;
+
+    if (!ctx)
+        return NULL;
+
+    if (strcmp(da->field, "source_ip") == 0) {
+        if (ctx->clientaddr) {
+            val = addr2string(ctx->clientaddr, buf, sizeof(buf));
+            /* addr2string returns literal "getnameinfo_failed" on failure,
+             * not NULL. Use pointer identity to detect success. */
+            if (val != buf)
+                val = NULL;
+        }
+    } else if (strcmp(da->field, "source_port") == 0) {
+        if (ctx->clientaddr) {
+            uint16_t p = port_get(ctx->clientaddr);
+            if (p > 0) {
+                snprintf(portbuf, sizeof(portbuf), "%u", p);
+                val = portbuf;
+            }
+        }
+    } else if (strcmp(da->field, "client_name") == 0) {
+        val = ctx->clientname;
+    }
+
+    if (!val || !*val) {
+        debug(DBG_INFO, "resolvedynattr: failed to resolve %s", da->field);
+        return NULL;
+    }
+
+    if (strlen(val) > RAD_Max_Attr_Value_Length) {
+        debug(DBG_INFO, "resolvedynattr: value too long for %s", da->field);
+        return NULL;
+    }
+
+    a = maketlv(da->t, strlen(val), (void *)val);
+    if (!a)
+        return NULL;
+    if (da->vendor) {
+        struct tlv *va = makevendortlv(da->vendor, a);
+        if (!va) {
+            freetlv(a);
+            return NULL;
+        }
+        a = va;
+    }
+    return a;
+}
+
 void addrewrite(char *value, uint8_t whitelist_mode, char **rmattrs, char **rmvattrs, char **addattrs,
-                char **addvattrs, char **modattrs, char **modvattrs, char **supattrs, char **supvattrs) {
+                char **addvattrs, char **modattrs, char **modvattrs, char **supattrs, char **supvattrs,
+                char **addmetaattrs, char **addmetavattrs, char **supmetaattrs, char **supmetavattrs) {
     struct rewrite *rewrite = NULL;
     int i, n;
     uint8_t *rma = NULL;
     uint32_t *p, *rmva = NULL;
     struct list *adda = NULL, *moda = NULL, *modva = NULL, *supa = NULL;
+    struct list *addma = NULL, *supma = NULL;
     struct tlv *a;
     struct modattr *m;
+    struct dynattr *da;
 
     if (rmattrs) {
         for (n = 0; rmattrs[n];)
@@ -279,7 +383,65 @@ void addrewrite(char *value, uint8_t whitelist_mode, char **rmattrs, char **rmva
         freegconfmstr(supvattrs);
     }
 
-    if (rma || rmva || adda || moda || modva || supa) {
+    if (addmetaattrs) {
+        addma = list_create();
+        if (!addma)
+            debugx(1, DBG_ERR, "malloc failed");
+        for (i = 0; addmetaattrs[i]; i++) {
+            da = extractdynattr(addmetaattrs[i], 0);
+            if (!da)
+                debugx(1, DBG_ERR, "addrewrite: invalid meta attribute %s", addmetaattrs[i]);
+            if (!list_push(addma, da))
+                debugx(1, DBG_ERR, "malloc failed");
+        }
+        freegconfmstr(addmetaattrs);
+    }
+
+    if (addmetavattrs) {
+        if (!addma)
+            addma = list_create();
+        if (!addma)
+            debugx(1, DBG_ERR, "malloc failed");
+        for (i = 0; addmetavattrs[i]; i++) {
+            da = extractdynattr(addmetavattrs[i], 1);
+            if (!da)
+                debugx(1, DBG_ERR, "addrewrite: invalid meta vendor attribute %s", addmetavattrs[i]);
+            if (!list_push(addma, da))
+                debugx(1, DBG_ERR, "malloc failed");
+        }
+        freegconfmstr(addmetavattrs);
+    }
+
+    if (supmetaattrs) {
+        supma = list_create();
+        if (!supma)
+            debugx(1, DBG_ERR, "malloc failed");
+        for (i = 0; supmetaattrs[i]; i++) {
+            da = extractdynattr(supmetaattrs[i], 0);
+            if (!da)
+                debugx(1, DBG_ERR, "addrewrite: invalid meta attribute %s", supmetaattrs[i]);
+            if (!list_push(supma, da))
+                debugx(1, DBG_ERR, "malloc failed");
+        }
+        freegconfmstr(supmetaattrs);
+    }
+
+    if (supmetavattrs) {
+        if (!supma)
+            supma = list_create();
+        if (!supma)
+            debugx(1, DBG_ERR, "malloc failed");
+        for (i = 0; supmetavattrs[i]; i++) {
+            da = extractdynattr(supmetavattrs[i], 1);
+            if (!da)
+                debugx(1, DBG_ERR, "addrewrite: invalid meta vendor attribute %s", supmetavattrs[i]);
+            if (!list_push(supma, da))
+                debugx(1, DBG_ERR, "malloc failed");
+        }
+        freegconfmstr(supmetavattrs);
+    }
+
+    if (rma || rmva || adda || moda || modva || supa || addma || supma) {
         rewrite = malloc(sizeof(struct rewrite));
         if (!rewrite)
             debugx(1, DBG_ERR, "malloc failed");
@@ -290,6 +452,8 @@ void addrewrite(char *value, uint8_t whitelist_mode, char **rmattrs, char **rmva
         rewrite->modattrs = moda;
         rewrite->modvattrs = modva;
         rewrite->supattrs = supa;
+        rewrite->addmetaattrs = addma;
+        rewrite->supmetaattrs = supma;
     }
 
     if (!rewriteconfs)
@@ -585,7 +749,40 @@ int dorewritesup(struct radmsg *msg, struct list *supattrs) {
     return 1;
 }
 
-int dorewrite(struct radmsg *msg, struct rewrite *rewrite) {
+static int dorewriteaddmeta(struct radmsg *msg, struct list *addmetaattrs, struct rewrite_context *ctx) {
+    struct list_node *n;
+    struct tlv *a;
+
+    for (n = list_first(addmetaattrs); n; n = list_next(n)) {
+        a = resolvedynattr((struct dynattr *)n->data, ctx);
+        if (!a)
+            continue;
+        if (!radmsg_add(msg, a, 0)) {
+            freetlv(a);
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static int dorewritesupmeta(struct radmsg *msg, struct list *supmetaattrs, struct rewrite_context *ctx) {
+    struct list_node *n;
+    struct tlv *a;
+
+    for (n = list_first(supmetaattrs); n; n = list_next(n)) {
+        a = resolvedynattr((struct dynattr *)n->data, ctx);
+        if (!a)
+            continue;
+        if (!dorewritesupattr(msg, a)) {
+            freetlv(a);
+            return 0;
+        }
+        freetlv(a);
+    }
+    return 1;
+}
+
+int dorewrite(struct radmsg *msg, struct rewrite *rewrite, struct rewrite_context *ctx) {
     int rv = 1; /* Success.  */
 
     if (rewrite) {
@@ -597,9 +794,25 @@ int dorewrite(struct radmsg *msg, struct rewrite *rewrite) {
         if (rewrite->supattrs)
             if (!dorewritesup(msg, rewrite->supattrs))
                 rv = 0;
+        if (rewrite->supmetaattrs) {
+            if (ctx) {
+                if (!dorewritesupmeta(msg, rewrite->supmetaattrs, ctx))
+                    rv = 0;
+            } else {
+                debug(DBG_WARN, "dorewrite: supmetaattrs configured but no rewrite_context");
+            }
+        }
         if (rewrite->addattrs)
             if (!dorewriteadd(msg, rewrite->addattrs))
                 rv = 0;
+        if (rewrite->addmetaattrs) {
+            if (ctx) {
+                if (!dorewriteaddmeta(msg, rewrite->addmetaattrs, ctx))
+                    rv = 0;
+            } else {
+                debug(DBG_WARN, "dorewrite: addmetaattrs configured but no rewrite_context");
+            }
+        }
     }
     return rv;
 }

--- a/rewrite.h
+++ b/rewrite.h
@@ -8,11 +8,24 @@
 #include "radmsg.h"
 #include <regex.h>
 
+struct sockaddr;
+
 struct modattr {
     uint8_t t;
     uint32_t vendor;
     char *replacement;
     regex_t *regex;
+};
+
+struct dynattr {
+    uint8_t t;
+    uint32_t vendor;
+    char *field;
+};
+
+struct rewrite_context {
+    struct sockaddr *clientaddr;
+    char *clientname;
 };
 
 struct rewrite {
@@ -23,12 +36,16 @@ struct rewrite {
     struct list *modattrs;       /*struct modattr*/
     struct list *modvattrs;      /*struct modattr*/
     struct list *supattrs;       /*struct tlv*/
+    struct list *addmetaattrs;   /*struct dynattr*/
+    struct list *supmetaattrs;   /*struct dynattr*/
 };
 
 void addrewrite(char *value, uint8_t whitelist_mode, char **rmattrs, char **rmvattrs, char **addattrs,
-                char **addvattrs, char **modattrs, char **modvattrs, char **supattrs, char **supvattrs);
-int dorewrite(struct radmsg *msg, struct rewrite *rewrite);
+                char **addvattrs, char **modattrs, char **modvattrs, char **supattrs, char **supvattrs,
+                char **addmetaattrs, char **addmetavattrs, char **supmetaattrs, char **supmetavattrs);
+int dorewrite(struct radmsg *msg, struct rewrite *rewrite, struct rewrite_context *ctx);
 struct modattr *extractmodattr(char *nameval);
+struct dynattr *extractdynattr(char *nameval, char vendor_flag);
 struct rewrite *getrewrite(char *alt1, char *alt2);
 
 int dorewritemodattr(struct tlv *attr, struct modattr *modattr);

--- a/tests/t_rewrite.c
+++ b/tests/t_rewrite.c
@@ -4,6 +4,7 @@
 #include "../debug.h"
 #include "../radmsg.h"
 #include "../rewrite.h"
+#include <arpa/inet.h>
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -29,7 +30,7 @@ _check_rewrite(struct list *origattrs, struct rewrite *rewrite, struct list *exp
 
     msg.attrs = origattrs;
 
-    if (dorewrite(&msg, rewrite) == shouldfail) {
+    if (dorewrite(&msg, rewrite, NULL) == shouldfail) {
         if (shouldfail)
             printf("dorewrite expected to fail, but it didn't\n");
         else
@@ -73,6 +74,14 @@ void _tlv_list_clear(struct list *list) {
         freetlv(tlv);
 }
 
+void _dynattr_list_clear(struct list *list) {
+    struct dynattr *da;
+    while ((da = (struct dynattr *)list_shift(list))) {
+        free(da->field);
+        free(da);
+    }
+}
+
 void _reset_rewrite(struct rewrite *rewrite) {
     rewrite->whitelist_mode = 0;
     rewrite->removeattrs = NULL;
@@ -81,10 +90,22 @@ void _reset_rewrite(struct rewrite *rewrite) {
     _list_clear(rewrite->modattrs);
     _list_clear(rewrite->modvattrs);
     _tlv_list_clear(rewrite->supattrs);
+    _dynattr_list_clear(rewrite->addmetaattrs);
+    _dynattr_list_clear(rewrite->supmetaattrs);
+}
+
+static struct dynattr *makedynattr(uint8_t t, uint32_t vendor, const char *field) {
+    struct dynattr *da = malloc(sizeof(struct dynattr));
+    if (!da)
+        return NULL;
+    da->t = t;
+    da->vendor = vendor;
+    da->field = strdup(field);
+    return da;
 }
 
 int main(int argc, char *argv[]) {
-    int testcount = 26;
+    int testcount = 35;
     struct list *origattrs, *expectedattrs;
     struct rewrite rewrite;
     char *username = "user@realm";
@@ -101,6 +122,8 @@ int main(int argc, char *argv[]) {
     rewrite.modattrs = list_create();
     rewrite.modvattrs = list_create();
     rewrite.supattrs = list_create();
+    rewrite.addmetaattrs = list_create();
+    rewrite.supmetaattrs = list_create();
 
     printf("1..%d\n", testcount);
     testcount = 1;
@@ -689,12 +712,257 @@ int main(int argc, char *argv[]) {
         _reset_rewrite(&rewrite);
     }
 
+    /* test meta add source_ip IPv4 */
+    {
+        struct sockaddr_in sa4;
+        struct rewrite_context ctx;
+        struct radmsg msg;
+        char *expected_ip = "192.168.1.5";
+
+        memset(&sa4, 0, sizeof(sa4));
+        sa4.sin_family = AF_INET;
+        sa4.sin_port = htons(1812);
+        inet_pton(AF_INET, expected_ip, &sa4.sin_addr);
+        ctx.clientaddr = (struct sockaddr *)&sa4;
+        ctx.clientname = "testclient";
+
+        list_push(rewrite.addmetaattrs, makedynattr(31, 0, "source_ip"));
+
+        msg.attrs = origattrs;
+        list_push(expectedattrs, maketlv(31, strlen(expected_ip), expected_ip));
+
+        if (dorewrite(&msg, &rewrite, &ctx) != 1 ||
+            list_count(msg.attrs) != 1 ||
+            !eqtlv((struct tlv *)list_first(msg.attrs)->data,
+                    (struct tlv *)list_first(expectedattrs)->data))
+            printf("not ");
+        printf("ok %d - meta add source_ip IPv4\n", testcount++);
+        _tlv_list_clear(origattrs);
+        _tlv_list_clear(expectedattrs);
+        _reset_rewrite(&rewrite);
+    }
+
+    /* test meta add source_ip IPv6 */
+    {
+        struct sockaddr_in6 sa6;
+        struct rewrite_context ctx;
+        struct radmsg msg;
+        char *expected_ip = "2001:db8::1";
+
+        memset(&sa6, 0, sizeof(sa6));
+        sa6.sin6_family = AF_INET6;
+        sa6.sin6_port = htons(1812);
+        inet_pton(AF_INET6, expected_ip, &sa6.sin6_addr);
+        ctx.clientaddr = (struct sockaddr *)&sa6;
+        ctx.clientname = "testclient";
+
+        list_push(rewrite.addmetaattrs, makedynattr(31, 0, "source_ip"));
+
+        msg.attrs = origattrs;
+        list_push(expectedattrs, maketlv(31, strlen(expected_ip), expected_ip));
+
+        if (dorewrite(&msg, &rewrite, &ctx) != 1 ||
+            list_count(msg.attrs) != 1 ||
+            !eqtlv((struct tlv *)list_first(msg.attrs)->data,
+                    (struct tlv *)list_first(expectedattrs)->data))
+            printf("not ");
+        printf("ok %d - meta add source_ip IPv6\n", testcount++);
+        _tlv_list_clear(origattrs);
+        _tlv_list_clear(expectedattrs);
+        _reset_rewrite(&rewrite);
+    }
+
+    /* test meta add source_port */
+    {
+        struct sockaddr_in sa4;
+        struct rewrite_context ctx;
+        struct radmsg msg;
+        char *expected_port = "1812";
+
+        memset(&sa4, 0, sizeof(sa4));
+        sa4.sin_family = AF_INET;
+        sa4.sin_port = htons(1812);
+        inet_pton(AF_INET, "10.0.0.1", &sa4.sin_addr);
+        ctx.clientaddr = (struct sockaddr *)&sa4;
+        ctx.clientname = "testclient";
+
+        list_push(rewrite.addmetaattrs, makedynattr(5, 0, "source_port"));
+
+        msg.attrs = origattrs;
+        list_push(expectedattrs, maketlv(5, strlen(expected_port), expected_port));
+
+        if (dorewrite(&msg, &rewrite, &ctx) != 1 ||
+            list_count(msg.attrs) != 1 ||
+            !eqtlv((struct tlv *)list_first(msg.attrs)->data,
+                    (struct tlv *)list_first(expectedattrs)->data))
+            printf("not ");
+        printf("ok %d - meta add source_port\n", testcount++);
+        _tlv_list_clear(origattrs);
+        _tlv_list_clear(expectedattrs);
+        _reset_rewrite(&rewrite);
+    }
+
+    /* test meta add client_name */
+    {
+        struct sockaddr_in sa4;
+        struct rewrite_context ctx;
+        struct radmsg msg;
+        char *expected_name = "testclient";
+
+        memset(&sa4, 0, sizeof(sa4));
+        sa4.sin_family = AF_INET;
+        ctx.clientaddr = (struct sockaddr *)&sa4;
+        ctx.clientname = expected_name;
+
+        list_push(rewrite.addmetaattrs, makedynattr(32, 0, "client_name"));
+
+        msg.attrs = origattrs;
+        list_push(expectedattrs, maketlv(32, strlen(expected_name), expected_name));
+
+        if (dorewrite(&msg, &rewrite, &ctx) != 1 ||
+            list_count(msg.attrs) != 1 ||
+            !eqtlv((struct tlv *)list_first(msg.attrs)->data,
+                    (struct tlv *)list_first(expectedattrs)->data))
+            printf("not ");
+        printf("ok %d - meta add client_name\n", testcount++);
+        _tlv_list_clear(origattrs);
+        _tlv_list_clear(expectedattrs);
+        _reset_rewrite(&rewrite);
+    }
+
+    /* test meta supplement non-existing */
+    {
+        struct sockaddr_in sa4;
+        struct rewrite_context ctx;
+        struct radmsg msg;
+        char *expected_ip = "10.0.0.1";
+
+        memset(&sa4, 0, sizeof(sa4));
+        sa4.sin_family = AF_INET;
+        inet_pton(AF_INET, expected_ip, &sa4.sin_addr);
+        ctx.clientaddr = (struct sockaddr *)&sa4;
+        ctx.clientname = "testclient";
+
+        list_push(rewrite.supmetaattrs, makedynattr(31, 0, "source_ip"));
+
+        msg.attrs = origattrs;
+        list_push(expectedattrs, maketlv(31, strlen(expected_ip), expected_ip));
+
+        if (dorewrite(&msg, &rewrite, &ctx) != 1 ||
+            list_count(msg.attrs) != 1 ||
+            !eqtlv((struct tlv *)list_first(msg.attrs)->data,
+                    (struct tlv *)list_first(expectedattrs)->data))
+            printf("not ");
+        printf("ok %d - meta supplement non-existing\n", testcount++);
+        _tlv_list_clear(origattrs);
+        _tlv_list_clear(expectedattrs);
+        _reset_rewrite(&rewrite);
+    }
+
+    /* test meta supplement existing - should not add */
+    {
+        struct sockaddr_in sa4;
+        struct rewrite_context ctx;
+        struct radmsg msg;
+        char *existing_val = "existing";
+
+        memset(&sa4, 0, sizeof(sa4));
+        sa4.sin_family = AF_INET;
+        inet_pton(AF_INET, "10.0.0.1", &sa4.sin_addr);
+        ctx.clientaddr = (struct sockaddr *)&sa4;
+        ctx.clientname = "testclient";
+
+        list_push(rewrite.supmetaattrs, makedynattr(31, 0, "source_ip"));
+        list_push(origattrs, maketlv(31, strlen(existing_val), existing_val));
+        list_push(expectedattrs, maketlv(31, strlen(existing_val), existing_val));
+
+        msg.attrs = origattrs;
+
+        if (dorewrite(&msg, &rewrite, &ctx) != 1 ||
+            list_count(msg.attrs) != 1 ||
+            !eqtlv((struct tlv *)list_first(msg.attrs)->data,
+                    (struct tlv *)list_first(expectedattrs)->data))
+            printf("not ");
+        printf("ok %d - meta supplement existing\n", testcount++);
+        _tlv_list_clear(origattrs);
+        _tlv_list_clear(expectedattrs);
+        _reset_rewrite(&rewrite);
+    }
+
+    /* test meta add vendor attribute */
+    {
+        struct sockaddr_in sa4;
+        struct rewrite_context ctx;
+        struct radmsg msg;
+        char *expected_ip = "10.0.0.1";
+
+        memset(&sa4, 0, sizeof(sa4));
+        sa4.sin_family = AF_INET;
+        inet_pton(AF_INET, expected_ip, &sa4.sin_addr);
+        ctx.clientaddr = (struct sockaddr *)&sa4;
+        ctx.clientname = "testclient";
+
+        list_push(rewrite.addmetaattrs, makedynattr(1, 12345, "source_ip"));
+
+        msg.attrs = origattrs;
+        list_push(expectedattrs, makevendortlv(12345, maketlv(1, strlen(expected_ip), expected_ip)));
+
+        if (dorewrite(&msg, &rewrite, &ctx) != 1 ||
+            list_count(msg.attrs) != 1 ||
+            !eqtlv((struct tlv *)list_first(msg.attrs)->data,
+                    (struct tlv *)list_first(expectedattrs)->data))
+            printf("not ");
+        printf("ok %d - meta add vendor attribute\n", testcount++);
+        _tlv_list_clear(origattrs);
+        _tlv_list_clear(expectedattrs);
+        _reset_rewrite(&rewrite);
+    }
+
+    /* test meta with NULL context - should skip gracefully */
+    {
+        struct radmsg msg;
+
+        list_push(rewrite.addmetaattrs, makedynattr(31, 0, "source_ip"));
+
+        msg.attrs = origattrs;
+
+        if (dorewrite(&msg, &rewrite, NULL) != 1 ||
+            list_count(msg.attrs) != 0)
+            printf("not ");
+        printf("ok %d - meta with NULL context\n", testcount++);
+        _tlv_list_clear(origattrs);
+        _tlv_list_clear(expectedattrs);
+        _reset_rewrite(&rewrite);
+    }
+
+    /* test extractdynattr rejects invalid input */
+    {
+        char *invalid_keyword = strdup("31:bogus_field");
+        char *missing_colon = strdup("31");
+        char *vendor_zero = strdup("0:1:source_ip");
+        char *name_zero = strdup("0:source_ip");
+
+        if (extractdynattr(invalid_keyword, 0) != NULL ||
+            extractdynattr(missing_colon, 0) != NULL ||
+            extractdynattr(vendor_zero, 1) != NULL ||
+            extractdynattr(name_zero, 0) != NULL)
+            printf("not ");
+        printf("ok %d - extractdynattr rejects invalid input\n", testcount++);
+
+        free(invalid_keyword);
+        free(missing_colon);
+        free(vendor_zero);
+        free(name_zero);
+    }
+
     list_destroy(origattrs);
     list_destroy(expectedattrs);
     list_destroy(rewrite.addattrs);
     list_destroy(rewrite.modattrs);
     list_destroy(rewrite.modvattrs);
     list_destroy(rewrite.supattrs);
+    list_destroy(rewrite.addmetaattrs);
+    list_destroy(rewrite.supmetaattrs);
 
     return 0;
 }

--- a/tests/t_rewrite_config.c
+++ b/tests/t_rewrite_config.c
@@ -28,7 +28,8 @@ int main(int argc, char *argv[]) {
         expected = maketlv(1, 8, expectedvalue);
 
         addrewrite(rewritename, 0, NULL, NULL, addattrs,
-                   NULL, NULL, NULL, NULL, NULL);
+                   NULL, NULL, NULL, NULL, NULL,
+                   NULL, NULL, NULL, NULL);
 
         result = getrewrite(rewritename, NULL);
 
@@ -59,7 +60,8 @@ int main(int argc, char *argv[]) {
         modvattrs[0] = stringcopy("9:102:/^(h323-credit-time).*$/\\1=86400/", 0);
         modvattrs[1] = NULL;
 
-        addrewrite(rewritename, 0, NULL, NULL, NULL, NULL, NULL, modvattrs, NULL, NULL);
+        addrewrite(rewritename, 0, NULL, NULL, NULL, NULL, NULL, modvattrs, NULL, NULL,
+                   NULL, NULL, NULL, NULL);
         result = getrewrite(rewritename, NULL);
 
         if (result && result->modvattrs && result->modvattrs->first) {

--- a/udp.c
+++ b/udp.c
@@ -122,16 +122,6 @@ static int addr_equal(struct sockaddr *a, struct sockaddr *b) {
     }
 }
 
-uint16_t port_get(struct sockaddr *sa) {
-    switch (sa->sa_family) {
-    case AF_INET:
-        return ntohs(((struct sockaddr_in *)sa)->sin_port);
-    case AF_INET6:
-        return ntohs(((struct sockaddr_in6 *)sa)->sin6_port);
-    }
-    return 0;
-}
-
 /* exactly one of client and server must be non-NULL */
 /* return who we received from in *client or *server */
 /* return from in sa if not NULL */

--- a/util.c
+++ b/util.c
@@ -110,6 +110,16 @@ void port_set(struct sockaddr *sa, uint16_t port) {
     }
 }
 
+uint16_t port_get(struct sockaddr *sa) {
+    switch (sa->sa_family) {
+    case AF_INET:
+        return ntohs(((struct sockaddr_in *)sa)->sin_port);
+    case AF_INET6:
+        return ntohs(((struct sockaddr_in6 *)sa)->sin6_port);
+    }
+    return 0;
+}
+
 struct sockaddr *addr_copy(struct sockaddr *in) {
     struct sockaddr *out = NULL;
 

--- a/util.h
+++ b/util.h
@@ -16,6 +16,7 @@ int verifyutf8(const unsigned char *str, size_t str_len);
 const char *addr2string(struct sockaddr *addr, char *buf, size_t len);
 struct sockaddr *addr_copy(struct sockaddr *in);
 void port_set(struct sockaddr *sa, uint16_t port);
+uint16_t port_get(struct sockaddr *sa);
 void sock_dgram_skip(int socket);
 
 void printfchars(char *prefixfmt, char *prefix, char *charfmt, uint8_t *chars, int len);


### PR DESCRIPTION
New rewrite ops add or supplement RADIUS attributes whose values are resolved at runtime from client connection metadata:

- addMetaAttribute / addMetaVendorAttribute
- supplementMetaAttribute / supplementMetaVendorAttribute

Supported keywords: source_ip, source_port, client_name. Metadata
always references the originating client, even on response paths,
so upstream proxies can preserve the original client identity.

dorewrite() now takes a rewrite_context carrying the client sockaddr
and config block name; call sites in radsrv() and replyh() pass it.
NULL context skips meta ops with a warning instead of failing.

port_get() moved from udp.c to util.c so rewrite.c can link it
without dragging in UDP-specific code.

addresses: https://github.com/radsecproxy/radsecproxy/discussions/126#discussion-5236232