### PR TITLE
Fix DTLS reconnect loop by resetting lost request counter

### DIFF
--- a/dtls.c
+++ b/dtls.c
@@ -525,6 +525,7 @@ int dtlsconnect(struct server *server, int timeout, int reconnect) {
 
     pthread_mutex_lock(&server->lock);
     server->state = RSP_SERVER_STATE_CONNECTED;
+    server->lostrqs = 0;
     pthread_mutex_unlock(&server->lock);
     pthread_mutex_lock(&server->newrq_mutex);
     server->conreset = reconnect;


### PR DESCRIPTION
Fixes #199.

This resets `lostrqs` after a successful DTLS reconnect, matching the existing TLS and TCP behavior.

Without this, a stale non-zero `lostrqs` value from a previous Status-Server timeout can cause the next reader timeout to close the newly established DTLS connection again.

Tests:
- `make check` passes, 241 tests