### PR TITLE
rewrite.c: avoid undefined behaviour if signed char value is negative.

### DIFF
--- a/rewrite.c
+++ b/rewrite.c
@@ -45,7 +45,7 @@ struct tlv *extractattr(char *nameval, char vendor_flag) {
     }
 
     s++;
-    if (isdigit((int)*s)) {
+    if (isdigit((unsigned char)*s)) {
         ival = atoi(s);
         ival = htonl(ival);
         len = 4;


### PR DESCRIPTION
Ref. the CAVEATS section in https://man.netbsd.org/ctype.3